### PR TITLE
Rules2022/50 ロボット交代ルールの明確化と"リモコン"の導入

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -138,24 +138,37 @@ Individual game events can be disabled completely or in some automatic referee i
 存在する実装はGithubで確認することができる。: https://github.com/RoboCup-SSL/ssl-autorefs +
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.
 
-==== Remote Control
+==== リモコン/Remote Control
+各チームに1台のリモコンが大会運営よりオプションで提供される。
+これは次のようなコマンドを受け付けるものである:
 A remote control for each team can optionally be provided by the tournament organizers.
 It is a physical device that allows entering the following commands:
 
-- Raise a challenge flag
-- Request a timeout
-- Request robot substitution
-- Request emergency stop
-- Change the keeper id
+- チャレンジフラッグを揚げる +
+Raise a challenge flag
+- タイムアウトを要求する +
+Request a timeout
+- ロボットの交代を要求する +
+Request robot substitution
+- 非常停止を要求する +
+Request emergency stop
+- キーパーのIDを変更する +
+Change the keeper id
 
+また、これは次のようなフィードバック情報を提供するかもしれない: +
 It may also provide feedback information, like:
 
-- Number of yellow cards and when they are due
-- Number of robots currently allowed
-- Number of robots currently on the field
+- イエローカードの枚数、およびその有効期限 +
+Number of yellow cards and when they are due
+- 現時点で許可されているロボットの台数 +
+Number of robots currently allowed
+- 現時点でフィールド上にあるロボットの台数 +
+Number of robots currently on the field
 
-The remote control may only be used by the <Robot Handler, robot handler>. There is always only one remote control per team, per match.
+リモコンは<<ハンドラー/Robot Handler, ハンドラー>>のみによって使用されるだろう。各試合において各チームに提供されるリモコンは常に1台のみである。 +
+The remote control may only be used by the <<ハンドラー/Robot Handler, robot handler>>. There is always only one remote control per team, per match.
 
+リーグでの公式な実装はGitHub上で確認できる: https://github.com/RoboCup-SSL/ssl-remote-control
 The official implementation for the league can be found on GitHub: https://github.com/RoboCup-SSL/ssl-remote-control.
 
 === コミュニケーションフラッグ/Communication Flags
@@ -171,8 +184,8 @@ The <<主審/Referee, referee>> or <<Game Controller Operator, game controller o
 Any gesturing and yelling will be considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>, punished by a <<レッドカード/Red Card, red card>> after the first warning.
 
 コミュニケーションフラッグは大会主催者より提供される。
-リモートコントロールソフトウェアやデバイスも提供される場合があり、その場合は物理的なフラッグを置き換える。
+<<リモコン/Remote Control, リモートコントロール>>ソフトウェアやデバイスも提供される場合があり、その場合は物理的なフラッグを置き換える。
 主催者が実行可能と判断した他の方法も使用できる。 +
 The communication flags are provided by the organizers of the competition.
-A <<Remote Control, remote control>> software or device can be provided and replace physical flags.
+A <<リモコン/Remote Control, remote control>> software or device can be provided and replace physical flags.
 Any other solution that the organizers find feasible can also be used.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -138,6 +138,26 @@ Individual game events can be disabled completely or in some automatic referee i
 存在する実装はGithubで確認することができる。: https://github.com/RoboCup-SSL/ssl-autorefs +
 Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.
 
+==== Remote Control
+A remote control for each team can optionally be provided by the tournament organizers.
+It is a physical device that allows entering the following commands:
+
+- Raise a challenge flag
+- Request a timeout
+- Request robot substitution
+- Request emergency stop
+- Change the keeper id
+
+It may also provide feedback information, like:
+
+- Number of yellow cards and when they are due
+- Number of robots currently allowed
+- Number of robots currently on the field
+
+The remote control may only be used by the <Robot Handler, robot handler>. There is always only one remote control per team, per match.
+
+The official implementation for the league can be found on GitHub: https://github.com/RoboCup-SSL/ssl-remote-control.
+
 === コミュニケーションフラッグ/Communication Flags
 
 コミュニケーションフラッグは、試合中の<<主審/Referee, 主審>>に対するジェスチャーや野次を回避するために用いられる。
@@ -154,5 +174,5 @@ Any gesturing and yelling will be considered <<非スポーツマン行為/Unspo
 リモートコントロールソフトウェアやデバイスも提供される場合があり、その場合は物理的なフラッグを置き換える。
 主催者が実行可能と判断した他の方法も使用できる。 +
 The communication flags are provided by the organizers of the competition.
-A remote control software or device can be provided and replace physical flags.
+A <<Remote Control, remote control>> software or device can be provided and replace physical flags.
 Any other solution that the organizers find feasible can also be used.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -286,7 +286,7 @@ NOTE: このルールは、イエローカードを受け取った後、ゲー�
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
 NOTE: 2020年のルールでは、時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら2021年には、ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mのミッドライン上に配置され、相手チームのフリーキックとなる。 +
-In 2020 no penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in 2021, if the robot gets manually substituted, the ball is placed on the mid line and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
+No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the mid line and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -285,7 +285,7 @@ The 10 seconds can be extended indefinitely by the other team by sending an adva
 NOTE: このルールは、イエローカードを受け取った後、ゲームが自動的に停止しない可能性があることを意味する。しかしながら、例えば部品を落とすといった、イエローカードの対象となるファウルがあった場合はゲームは停止する。したがって、これらのファウルのいずれかが発生した場合、チームはロボットを手動で取り除くことができる。 +
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
-NOTE: 2020年のルールでは、時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら2021年には、ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mのミッドライン上に配置され、相手チームのフリーキックとなる。 +
+NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mのミッドライン上に配置され、相手チームのフリーキックとなる。 +
 No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the mid line and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -7,7 +7,7 @@ Robots are substituted by the <<ハンドラー/Robot Handler, robot handler>> o
 The <<ハンドラー/Robot Handler, robot handler>> should prefer to use long sleeves and colors that won't interfere with the vision system.
 
 以下のすべての条件に適合する場合は、ゲーム中のいつでも<<主審/Referee, 主審>>に確認を取ることなくロボットを交代させることができる: +
-Robots can always be substituted during game play without notifying the <<主審/Referee, referee>> if all the following conditions are met:
+Robots can always be taken in and out during game play without notifying the <<主審/Referee, referee>> if all the following conditions are met:
 
 . ロボットは少なくとも部分的に<<フィールドの表面/Field Surface, フィールドのマージン部分>>にある。 +
 The robot is at least partially inside the <<フィールドの表面/Field Surface, field margin>>.
@@ -17,8 +17,11 @@ The robot is at a distance from the halfway line that must not exceed 1 meter.
 The ball must be at least 2 meters away from the halfway line.
 
 加えて、<<試合の停止/Stopping The Game, ストップゲーム中>>であれば、ロボットはどの位置からでも以下の手順に従い<<ハンドラー/Robot Handler, ハンドラー>>により交代させられる: +
-Additionally, robots can be taken out from any position during <<試合の停止/Stopping The Game, game stoppage>> by the <<ハンドラー/Robot Handler, robot handler>> using the procedure below:
+Additionally, robots can be taken out from any position on request using the procedure below:
 
+. The <<Robot Handler, robot handler>> requests robot substitution at any time.
+. The <<Game Controller, game controller>> will <<Halt, halt>> the game at the next opportunity.
+. The <<Robot Handler, robot handler>> may enter the field and touch robots now, as long as the game is still <<Halt, halted>>.
 . <<ハンドラー/Robot Handler, ハンドラー>>はロボットを外に出す +
 The <<ハンドラー/Robot Handler, robot handler>> takes robots out.
 . <<ハンドラー/Robot Handler, ハンドラー>>は交代が完了したら<<主審/Referee, 主審>>に連絡する +
@@ -40,13 +43,14 @@ A robot substitution intent can be made by:
 
 . <<ハンドラー/Robot Handler, ハンドラー>>は<<Game Controller Operator, game controller operator>>に通知することで<<Game Controller, game controller>>に意図を入力する。 +
 A <<ハンドラー/Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
+. A <<Robot Handler, robot handler>> by using the <<Remote Control, remote control>>, if provided.
 . チームのソフトウェアは<<Game Controller, game controller>>へリクエストを送信する。 +
 A team software by sending a request to the <<Game Controller, game controller>>.
 . <<Game Controller, game controller>>は当該チームに許された最大ロボット数を超えていないかを確認し(例えばチームが<<イエローカード/Yellow Card, イエロー>>か<<レッドカード/Red Card, レッドカード>>を受け取ったあと等)、リクエストを処理する。 +
 The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<イエローカード/Yellow Card, yellow>> or <<レッドカード/Red Card, red card>>).
 
 片方のチームの交代の意図のために試合がハルトされた場合、少なくとも一度の交代(ロボットの除去、もしくは投入)が行われなければならない。交代のために試合がハルトされていない場合に限り交代の意図を取り消すことができる。 +
-If the game was halted due to a substitution intent by a team, at least one substitution (taking a robot out or putting one in) must be performed by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
+If the game was halted due to a substitution intent by a team, at least one robot must be taken out by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 
 ボール配置後、試合が継続する直前にどちらかのチームがロボットを交代する意思がある場合、<<Game Controller, game controller>>は自動的に試合を<<ハルト/Halt, ハルト>>する。 +
 If a robot substitution intent for either team is present just before the game would continue after ball placement, the <<Game Controller, game controller>> automatically <<ハルト/Halt, halts>> the game.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -43,7 +43,8 @@ A robot substitution intent can be made by:
 
 . <<ハンドラー/Robot Handler, ハンドラー>>は<<Game Controller Operator, game controller operator>>に通知することで<<Game Controller, game controller>>に意図を入力する。 +
 A <<ハンドラー/Robot Handler, robot handler>> by informing the <<Game Controller Operator, game controller operator>> who in turn enters the intent into the <<Game Controller, game controller>>.
-. A <<Robot Handler, robot handler>> by using the <<Remote Control, remote control>>, if provided.
+. <<ハンドラー/Robot Handler, ハンドラー>>は、提供されていれば<<リモコン/Remote Control, リモコン>>を使用する。 +
+A <<ハンドラー/Robot Handler, robot handler>> by using the <<リモコン/Remote Control, remote control>>, if provided.
 . チームのソフトウェアは<<Game Controller, game controller>>へリクエストを送信する。 +
 A team software by sending a request to the <<Game Controller, game controller>>.
 . <<Game Controller, game controller>>は当該チームに許された最大ロボット数を超えていないかを確認し(例えばチームが<<イエローカード/Yellow Card, イエロー>>か<<レッドカード/Red Card, レッドカード>>を受け取ったあと等)、リクエストを処理する。 +


### PR DESCRIPTION
[本家Pull Request 50](https://github.com/robocup-ssl/ssl-rules/pull/50)の作業です。 
タイトルにはありませんが、イエローカードに伴うロボット除去を自動で行えなかった場合のペナルティを導入する時期が2020年のままであったため、「おそらく2023年」("probably 2023")に延長されています。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
