### PR TITLE
無効なリンクの修正

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -174,7 +174,7 @@ The official implementation for the league can be found on GitHub: https://githu
 === コミュニケーションフラッグ/Communication Flags
 
 コミュニケーションフラッグは、試合中の<<主審/Referee, 主審>>に対するジェスチャーや野次を回避するために用いられる。
-これらのフラッグは<<タイムアウト/Timeout, タイムアウト>>や<<非常停止/Emergency stop, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
+これらのフラッグは<<タイムアウト/Timeouts, タイムアウト>>や<<非常停止/Emergency stop, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
 The communication flags are used to avoid gesturing and yelling with the <<主審/Referee, referee>> during a match.
 These flags are responsible for communicating various intents, such as: <<タイムアウト/Timeouts, timeouts>>, <<非常停止/Emergency stop, emergency stops>>, <<ロボットの交代/Robot Substitution, manual robot substitution>> and <<チャレンジフラッグ/Challenge Flags, challenges>>.
 


### PR DESCRIPTION
```sh
$ asciidoctor -a allow-uri-read -v sslrules.adoc
asciidoctor: INFO: possible invalid reference: タイムアウト/Timeout

$ for adoc_src in $(find . -name "*.adoc" -type f); do \
>   printf "%s: " "${adoc_src}"; \
>   grep "タイムアウト/Timeout," < "${adoc_src}" 2>&1 >/dev/null; grep_e_code="$?"; \
>   if [ "$grep_e_code" == 0 ];then \
>     echo "invalid link found"; \
>   else \
>     echo "OK";
>   fi;
> done
./chapters/appendix.adoc: OK
./chapters/ballleavesthefield.adoc: OK
./chapters/challengeflag.adoc: OK
./chapters/emergencystop.adoc: OK
./chapters/gamestructure.adoc: OK
./chapters/introduction.adoc: OK
./chapters/offenses.adoc: OK
./chapters/playingenvironment.adoc: invalid link found
./chapters/refereecommands.adoc: OK
./chapters/robots.adoc: OK
./chapters/rulechanges.adoc: OK
./chapters/scoringgoals.adoc: OK
./chapters/shootout.adoc: OK
./chapters/substitution.adoc: OK
./sslrules.adoc: OK
```