### PR TITLE
Rules2022/52 エイムレスキックとなる条件を「ハーフラインに交差して」に修正

### DIFF
--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -60,7 +60,7 @@ After the ball has been placed, a <<フリーキック/Free Kick, free kick>> is
 
 .用途/Usage
 ボールがロボットに触れたあと、ボールが他のロボットに触れることなく、ミッドラインに交差して相手チームのゴールラインからフィールド外にボールが出たとき、それはエイムレスキックである。 +
-A kick is aimless when after the ball touched a robot, it subsequently crossed the midline and then its opponent's goal line outside the goal without touching another robot.
+A kick is aimless when after the ball touched a robot, it subsequently crossed the halfline and then its opponent's goal line outside the goal without touching another robot.
 
 キックオフ時のキックは、ボールがミッドライン上に位置しておりミッドラインに交差していないため、エイムレスキックにはならない。 +
 A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -59,7 +59,7 @@ The ball has to be placed at the position from where the ball was kicked (see th
 After the ball has been placed, a <<フリーキック/Free Kick, free kick>> is awarded to the opponent of the team that last touched the ball before it left the field.
 
 .用途/Usage
-ボールがロボットに触れたあと、ボールが他のロボットに触れることなく、ミッドラインに交差して相手チームのゴールラインからフィールド外にボールが出たとき、それはエイムレスキックである。 +
+ボールがロボットに触れたあと、ボールが他のロボットに触れることなく、ハーフラインに交差して相手チームのゴールラインからフィールド外にボールが出たとき、それはエイムレスキックである。 +
 A kick is aimless when after the ball touched a robot, it subsequently crossed the halfline and then its opponent's goal line outside the goal without touching another robot.
 
 キックオフ時のキックは、ボールがミッドライン上に位置しておりミッドラインに交差していないため、エイムレスキックにはならない。 +


### PR DESCRIPTION
[本家Pull Request 52](https://github.com/robocup-ssl/ssl-rules/pull/52)の作業です。 
従来のルールにあった誤植を修正し、エイムレスキックとなる条件を「ミッドライン」(タッチラインと並行にフィールド中心からフィールドの両端にひかれているライン=長辺方向)ではなく「ハーフライン」(ゴールラインと平行にフィールド中心からフィールドの両端に引かれているライン=短辺方向)と交差して相手ゴールラインを通過したとき、とします。  

これらの定義は現在は"追加のライン/Additional Lines"に[まとめて記載されています](https://github.com/kkimurak/ssl-rules-ja/blame/4cec30e/chapters/playingenvironment.adoc#L54-L60)。本家PRのコメント欄にてこれらを個別の定義として独立させて必要に応じて参照できるようにするという提案が(長期的なものとして)なされていますが、今回のPRには含まれません。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
