### PR TITLE
Rules2023/55 ペナルティマークの位置の定義を明確化

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -69,7 +69,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 ===== ペナルティーマーク/Penalty Mark
 それぞれのディフェンスエリアのペナルティーマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の地点にある。 +
-For each field half the penalty mark is on the <<追加のライン/Additional Lines, mid-line>> (not halfway line), 8 meters (division A) or 6 meters (division B) away from the opponent goal center.
+The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<追加のライン/Additional Lines, mid-line>> (not halfway line) and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
 
 ==== ゴール/Goals
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければならない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの壁と角と上面は白色で塗装される。 +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -68,7 +68,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 
 ===== ペナルティーマーク/Penalty Mark
-それぞれのディフェンスエリアのペナルティーマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の地点にある。 +
+ペナルティーマークは一方のチームがもう一方のチームに対してペナルティーキックを行う際の開始点を定義する。ペナルティーマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の点に位置する。 +
 The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<追加のライン/Additional Lines, mid-line>> (not halfway line) and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
 
 ==== ゴール/Goals


### PR DESCRIPTION
[本家Pull Request 55](https://github.com/robocup-ssl/ssl-rules/pull/55)の作業です。 
従来のルールでは2か所あるペナルティーキックのどちらを使用するかが若干ですが曖昧でした。本PRによりこれを明確にします。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
