### PR TITLE
Rules2023/56 各フィールドラインの定義の明確化

### DIFF
--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -62,5 +62,5 @@ After the ball has been placed, a <<フリーキック/Free Kick, free kick>> is
 ボールがロボットに触れたあと、ボールが他のロボットに触れることなく、ハーフラインに交差して相手チームのゴールラインからフィールド外にボールが出たとき、それはエイムレスキックである。 +
 A kick is aimless when after the ball touched a robot, it subsequently crossed the halfline and then its opponent's goal line outside the goal without touching another robot.
 
-キックオフ時のキックは、ボールがミッドライン上に位置しておりミッドラインに交差していないため、エイムレスキックにはならない。 +
-A kick-off kick cannot be aimless, as the ball is located on the <<Halfway Line, halfway line>> and does therefore not cross it.
+キックオフ時のキックは、ボールが<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>上に位置しており交差していないため、エイムレスキックにはならない。 +
+A kick-off kick cannot be aimless, as the ball is located on the <<ハーフウェーライン/Halfway Line, halfway line>> and does therefore not cross it.

--- a/chapters/ballleavesthefield.adoc
+++ b/chapters/ballleavesthefield.adoc
@@ -63,4 +63,4 @@ After the ball has been placed, a <<フリーキック/Free Kick, free kick>> is
 A kick is aimless when after the ball touched a robot, it subsequently crossed the halfline and then its opponent's goal line outside the goal without touching another robot.
 
 キックオフ時のキックは、ボールがミッドライン上に位置しておりミッドラインに交差していないため、エイムレスキックにはならない。 +
-A kick-off kick cannot be aimless, as the ball is located at the midline and does therefore not cross it.
+A kick-off kick cannot be aimless, as the ball is located on the <<Halfway Line, halfway line>> and does therefore not cross it.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -51,19 +51,23 @@ Distances between lines are measured from their centers.
 プレイエリアは4本のラインで定義される。2本の長辺はタッチラインと呼ばれ、2本の短辺はゴールラインと呼ばれる。 +
 The playing area is defined by four field lines. The two longer field lines are called touch lines. The two shorter field lines are called goal lines.
 
-===== Halfway Line
+===== ハーフウェーライン/Halfway Line
+競技フィールドは、フィールドの短辺方向に走りフィールド中央を通るハーフウェーラインによって2つに分断される。
+ハーフウェーラインはゴールラインと平行である。 +
 The field of play is divided into two halves by a halfway line that runs along the width of the field and through the center of the field.
 The  halfway line is parallel to the goal lines.
 
-===== Goal-to-Goal Line
+===== ゴール・トゥ・ゴールライン/Goal-to-Goal Line
+ゴール・トゥ・ゴールラインはフィールドの長辺方向に走り、ゴールとフィールドの中央を通る。ゴール・トゥ・ゴールラインはタッチラインと平行である。 +
 The goal-to-goal line runs along the length of the field, passing through the center of the goals and the field. The goal-to-goal line is parallel to the touch lines.
 
-NOTE: This line is used to provide adequate features for the geometry calibration of the <<Vision, vision software>> and for optional local localisation of robots.
+NOTE: このラインは<<Vision, visionソフトウェア>>の座標補正や、ロボットによる自己位置推定に適切な機能を提供するために使用されていた。 +
+This line is used to provide adequate features for the geometry calibration of the <<Vision, vision software>> and for optional local localisation of robots.
 
 ===== センターサークル/Center Circle
-ハーフウェーラインの中央にセンターマークが印されている。サークルの直径はどちらのディヴィジョンでも1mである。 +
+センターサークルはフィールドの中央に印されており、直径は1メートルである。センターサークルの中心は<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>と<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>の交点にある。 +
 The center circle is located at the center of the field with a diameter of 1 meter.
-The center is at the crossing of the <<Halfway Line, halfway line>> and the <<Goal-to-Goal Line, goal-to-goal line>>.
+The center is at the crossing of the <<ハーフウェーライン/Halfway Line, halfway line>> and the <<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, goal-to-goal line>>.
 
 ===== ディフェンスエリア/Defense Area
 ディフェンスエリアは中心から見て両端にある<<ゴール/Goals, ゴール>>と接するゴールラインと接する長方形で定義される。ディフェンスエリアの大きさは<<field-dimensions-a, 図1>>と<<field-dimensions-b, 図2>>に示される通り、ディヴィジョンAであれば3.6m×1.8m、ディヴィジョンBであれば2m×1mである。 +
@@ -71,8 +75,8 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 
 ===== ペナルティーマーク/Penalty Mark
-ペナルティーマークは一方のチームがもう一方のチームに対してペナルティーキックを行う際の開始点を定義する。ペナルティーマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の点に位置する。 +
-The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<Goal-to-Goal Line, goal-to-goal line>> and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
+ペナルティーマークは一方のチームがもう一方のチームに対してペナルティーキックを行う際の開始点を定義する。ペナルティーマークは<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の点に位置する。 +
+The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, goal-to-goal line>> and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
 
 ==== ゴール/Goals
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければならない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの内壁は白色で、外壁と角および上面は黒色で塗装される。 +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -52,7 +52,7 @@ Distances between lines are measured from their centers.
 The playing area is defined by four field lines. The two longer field lines are called touch lines. The two shorter field lines are called goal lines.
 
 ===== Halfway Line
-The field of play is divided into two halves by a  halfway line that runs along the width of the field and through the center of the field.
+The field of play is divided into two halves by a halfway line that runs along the width of the field and through the center of the field.
 The  halfway line is parallel to the goal lines.
 
 ===== Goal-to-Goal Line

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -51,16 +51,19 @@ Distances between lines are measured from their centers.
 プレイエリアは4本のラインで定義される。2本の長辺はタッチラインと呼ばれ、2本の短辺はゴールラインと呼ばれる。 +
 The playing area is defined by four field lines. The two longer field lines are called touch lines. The two shorter field lines are called goal lines.
 
-===== 追加のライン/Additional Lines
-競技フィールドは、フィールド中心からフィールドの両端に引かれているハーフウェーラインによって半分に分割される。ハーフウェーラインはゴールラインと平行である。 +
-The field of play is divided into two halves by a halfway line that runs along the width of the field and through the center of the field. The halfway line is parallel to the goal lines.
+===== Halfway Line
+The field of play is divided into two halves by a  halfway line that runs along the width of the field and through the center of the field.
+The  halfway line is parallel to the goal lines.
 
-ミッドラインはフィールド中心からフィールドの長さ方向に沿って引かれている。ミッドラインはタッチラインと平行である。このラインは<<Vision, visionソフトウェア>>のジオメトリのキャリブレーションを適切に行うために必要な機能を提供するために使用される。 +
-A mid-line runs along the length of the field, passing through the center of the field. The mid-line is parallel to the touch lines. This line is used to provide adequate features for the geometry calibration of the <<Vision, vision software>>.
+===== Goal-to-Goal Line
+The goal-to-goal line runs along the length of the field, passing through the center of the goals and the field. The goal-to-goal line is parallel to the touch lines.
+
+NOTE: This line is used to provide adequate features for the geometry calibration of the <<Vision, vision software>> and for optional local localisation of robots.
 
 ===== センターサークル/Center Circle
 ハーフウェーラインの中央にセンターマークが印されている。サークルの直径はどちらのディヴィジョンでも1mである。 +
-The center mark is indicated at the midpoint of the halfway line. A circle with a diameter of 1 meter is marked around it for both divisions.
+The center circle is located at the center of the field with a diameter of 1 meter.
+The center is at the crossing of the <<Halfway Line, halfway line>> and the <<Goal-to-Goal Line, goal-to-goal line>>.
 
 ===== ディフェンスエリア/Defense Area
 ディフェンスエリアは中心から見て両端にある<<ゴール/Goals, ゴール>>と接するゴールラインと接する長方形で定義される。ディフェンスエリアの大きさは<<field-dimensions-a, 図1>>と<<field-dimensions-b, 図2>>に示される通り、ディヴィジョンAであれば3.6m×1.8m、ディヴィジョンBであれば2m×1mである。 +
@@ -69,7 +72,7 @@ A defense area is defined as a rectangle touching the goal lines centrally in fr
 
 ===== ペナルティーマーク/Penalty Mark
 ペナルティーマークは一方のチームがもう一方のチームに対してペナルティーキックを行う際の開始点を定義する。ペナルティーマークは(ハーフウェーラインではなく)<<追加のライン/Additional Lines, ミッドライン>>上の、相手チームのゴールのセンターから8m(ディヴィジョンA)もしくは6m(ディヴィジョンB)の点に位置する。 +
-The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<追加のライン/Additional Lines, mid-line>> (not halfway line) and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
+The penalty mark defines the point from which a team executes a penalty kick against the opponent goal. It is located on the <<Goal-to-Goal Line, goal-to-goal line>> and 8 meters (division A) or 6 meters (division B) away from the opponent's goal center.
 
 ==== ゴール/Goals
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければならない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの内壁は白色で、外壁と角および上面は黒色で塗装される。 +

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -286,7 +286,7 @@ NOTE: このルールは、イエローカードを受け取った後、ゲー�
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
 NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mのミッドライン上に配置され、相手チームのフリーキックとなる。 +
-No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the mid line and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
+NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the <<Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -285,8 +285,8 @@ The 10 seconds can be extended indefinitely by the other team by sending an adva
 NOTE: このルールは、イエローカードを受け取った後、ゲームが自動的に停止しない可能性があることを意味する。しかしながら、例えば部品を落とすといった、イエローカードの対象となるファウルがあった場合はゲームは停止する。したがって、これらのファウルのいずれかが発生した場合、チームはロボットを手動で取り除くことができる。 +
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
-NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mのミッドライン上に配置され、相手チームのフリーキックとなる。 +
-NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the <<Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
+NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mの<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上に配置され、相手チームのフリーキックとなる。 +
+NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the <<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -11,10 +11,10 @@ Robots can always be taken in and out during game play without notifying the <<�
 
 . ロボットは少なくとも部分的に<<フィールドの表面/Field Surface, フィールドのマージン部分>>にある。 +
 The robot is at least partially inside the <<フィールドの表面/Field Surface, field margin>>.
-. ロボットはハーフウェーラインから1mを超えない位置にある。 +
-The robot is at a distance from the <<Halfway Line, halfway line>> that must not exceed 1 meter.
-. ボールはハーフウェーラインから少なくとも2m離れた地点にある。 +
-The ball must be at least 2 meters away from the <<Halfway Line, halfway line>>.
+. ロボットは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から1mを超えない位置にある。 +
+The robot is at a distance from the <<ハーフウェーライン/Halfway Line, halfway line>> that must not exceed 1 meter.
+. ボールは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から少なくとも2m離れた地点にある。 +
+The ball must be at least 2 meters away from the <<ハーフウェーライン/Halfway Line, halfway line>>.
 
 加えて、要求があればロボットはどの位置からでも以下の手順に従い除去させられる: +
 Additionally, robots can be taken out from any position on request using the procedure below:

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -12,9 +12,9 @@ Robots can always be taken in and out during game play without notifying the <<�
 . ロボットは少なくとも部分的に<<フィールドの表面/Field Surface, フィールドのマージン部分>>にある。 +
 The robot is at least partially inside the <<フィールドの表面/Field Surface, field margin>>.
 . ロボットはハーフウェーラインから1mを超えない位置にある。 +
-The robot is at a distance from the halfway line that must not exceed 1 meter.
+The robot is at a distance from the <<Halfway Line, halfway line>> that must not exceed 1 meter.
 . ボールはハーフウェーラインから少なくとも2m離れた地点にある。 +
-The ball must be at least 2 meters away from the halfway line.
+The ball must be at least 2 meters away from the <<Halfway Line, halfway line>>.
 
 加えて、要求があればロボットはどの位置からでも以下の手順に従い除去させられる: +
 Additionally, robots can be taken out from any position on request using the procedure below:


### PR DESCRIPTION
[本家Pull Request 56](https://github.com/robocup-ssl/ssl-rules/pull/56)の作業です。 
"Additional Lines"として一括りに定義されていたフィールド上のライン2種類("Goal-to-Goal Line"および"Halfway Line")について個別に定義を作り、各ルール条文ではこれを参照することになります。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
