### PR TITLE
Rules2023/59 1回のボール配置につき計上されるファウルの上限を設定

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -215,7 +215,8 @@ speed limit is to avoid robots harming the people on the field.
 <<ボール配置/Ball Placement, ボール配置>>の間、配置を担当しないチームのすべてのロボットはボールと配置位置を結ぶラインから少なくとも0.5mは離れなければならない(この領域はスタジアム状の形になる)。 +
 During <<ボール配置/Ball Placement, ball placement>>, all robots of the non-placing team have to keep at least 0.5 meters distance to the line between the ball and the placement position (the forbidden area forms a stadium shape).
 
-ボール配置を担当しないチームのロボットが2秒以上に亘ってボールと配置場所を結ぶラインに接近した場合、ファウルとなる。この場合、ボール配置を行える時間が10秒だけ追加される。 +
+ボール配置を担当しないチームのロボットが2秒以上に亘ってボールと配置場所を結ぶラインに接近した場合、ファウルとなる。この場合、ボール配置を行える時間が10秒だけ追加される。
+1回のボール配置フェイズにつき1度の干渉のみをファウルとして計上する。ただしボール配置の猶予時間は干渉が起こるたびに延長される。 +
 If a robot of the non-placing team is too close to the line between
 the ball and the placement position for more than 2 seconds, it
 commits a foul. In this case, 10 seconds are added to the ball
@@ -227,4 +228,5 @@ NOTE: このルールは、ボール配置への干渉をすべてカバーす�
 This rule does not cover all cases of ball placement interference.
 The <<主審/Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
 
-NOTE: If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.
+NOTE: もしロボットが(たとえば立ち往生を起こした、動作できない、など)干渉を続ける場合、人間の審判はボール配置を止めて手動でボールを配置することが推奨される。 +
+If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -220,8 +220,11 @@ If a robot of the non-placing team is too close to the line between
 the ball and the placement position for more than 2 seconds, it
 commits a foul. In this case, 10 seconds are added to the ball
 placement timer.
+Only one interference foul per ball placement phase counts towards the foul counter, but the placement timer is always incremented.
 
 NOTE: このルールは、ボール配置への干渉をすべてカバーするものではない。
 <<主審/Referee, 主審>>はボール配置を担当しないチームが明らかにボール配置に干渉している場合は、ファウルを宣告することが推奨される。 +
 This rule does not cover all cases of ball placement interference.
 The <<主審/Referee, referee>> is encouraged to call fouls if the non-placing team is obviously interfering with the ball placement.
+
+NOTE: If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.


### PR DESCRIPTION
[本家Pull Request 59](https://github.com/robocup-ssl/ssl-rules/pull/59)の作業です。 
2022の世界大会を通じて、ロボットがボール配置中に立ち往生したり停止したりしたため2秒ごとにファウルが出され、高頻度でイエロー・レッドカードが出された事への対処です。  
ボール配置1フェイズにつき計上されるファウルは1回までとなります。  
ボール配置の持ち時間は干渉が起きるごとに10秒ずつ延長されます。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
