### PR TITLE
Fix : スペルミス

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -87,11 +87,11 @@ Team members are generally advised not to talk to the vision expert, unless they
 
 .職務/Duties
 
-* Vision expartはVisionのハードウェアをチェックし、あらゆる種類のハードウェアの問題を<<技術委員会/Technical Committee, 技術委員会>>に報告する。 +
+* Vision expertはVisionのハードウェアをチェックし、あらゆる種類のハードウェアの問題を<<技術委員会/Technical Committee, 技術委員会>>に報告する。 +
 The vision expert checks the vision hardware and reports any kind of hardware problems to the <<技術委員会/Technical Committee, technical committee>>
-* Vision expartは試合中に共有Visionシステムを監視し、あらゆる種類の問題を主審に即座に報告する。 +
+* Vision expertは試合中に共有Visionシステムを監視し、あらゆる種類の問題を主審に即座に報告する。 +
 The vision expert monitors the shared vision system during the match and reports any kind of problems to the referee instantly
-* 主審が必要であると考えた場合には、Vision expartはVision systemを再キャリブレーションする。 +
+* 主審が必要であると考えた場合には、Vision expertはVision systemを再キャリブレーションする。 +
 The vision expert recalibrates the vision system if the referee deems it necessary
 
 NOTE: (訳者注記)日本では一般的に「ビジョン」と呼称されることが多い。Visionソフトウェアそのものと混同される懸念があるが、Vision Expertが呼ばれるということはVisionソフトウェアに異常がある場合が大半であり、運用する上で支障があることはあまりない。

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -1,7 +1,7 @@
 == ロボット/Robots
 
 === ロボットの台数/Number Of Robots
-試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision pattarnに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
+試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).
 
 === ハードウェアとソフトウェアの制約/Hardware And Software Constraints


### PR DESCRIPTION
機械的なスペルチェックにかけました。  
原文がそうなっているもの("halfline"、"localisation"、"subwheel")や固有名詞("RoboCup"、"refbox")、画像ファイル名("lawsofthegame")は除外しています。