### PR TITLE
Rules2023/58 「ハルト」後にロボットが準備を行うための猶予時間を設定

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -28,7 +28,7 @@ There is a grace period of 2 seconds for the robots to brake.
 The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is
 also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<ロボットの交代/Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
 
-「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。 +
+「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。試合が続行される前に、各チームに十分な準備時間が与えられる。<<Game Controller, Game Controller>>は「ハルト」コマンドから最大で10秒間だけ待機するが、ロボットの準備ができていれば試合は続行できる。 +
 The halt command is always followed up by stop.
 Enough preparation time should be given to teams, before the game is continued.
 The <<Game Controller, game controller>> will wait for up to 10 seconds after a halt command, but the game can be continued if robots are prepared already.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -30,6 +30,8 @@ also used to recalibrate the vision software during a game if the vision expert 
 
 「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。 +
 The halt command is always followed up by stop.
+Enough preparation time should be given to teams, before the game is continued.
+The <<Game Controller, game controller>> will wait for up to 10 seconds after a halt command, but the game can be continued if robots are prepared already.
 
 
 === ボール配置/Ball Placement


### PR DESCRIPTION
[本家Pull Request 58](https://github.com/robocup-ssl/ssl-rules/pull/58)の作業です。 
「ハルト」コマンドで試合が停止された後、再開されるまでに最大で10秒間の猶予時間が設けられます。ロボットの準備ができていればこの時間は省略されます。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
