### PR TITLE
Rules2023/57 「ハルト」と「ストップ」コマンドの使用基準に関する補足の追加

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -25,11 +25,13 @@ There is a grace period of 2 seconds for the robots to brake.
 
 .用途/Usage
 (例えばロボットが制御不能になった時など)緊急事態が発生した時に主審は「ハルト」コマンドで試合を中断させることができる。また、Vision expertが必要と判断した場合にはVisionソフトウェアの再キャリブレーションにも使われ、主審が同意する場合には<<ロボットの交代/Robot Substitution, ロボットの交代>>にも使われる。さらに、主審は自由に「ハルト」コマンドを発行することができる。 +
-The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of contol). It is
+The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of control). It is
 also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<ロボットの交代/Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
 
 「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。 +
 The halt command is always followed up by stop.
+
+NOTE: As a rule of thumb, the game should always be halted when humans other than the referees are entering the field.
 
 
 === ボール配置/Ball Placement
@@ -38,6 +40,8 @@ The halt command is always followed up by stop.
 After the game was stopped, the ball must be placed on the appropriate position, depending on the event that occurred.
 The automatic ball placement is the preferred way to place the ball at the designated position on the field by the robots of the teams without human interaction.
 If this is not possible, the <<主審/Referee, referee>> places the ball manually.
+
+NOTE: During manual ball placement, the game should be in <<Stop, stop>> to allow robots to prepare for game continuation.
 
 以下の条件が全て満たされている場合、ボール配置は必要ない: +
 No ball placement is required if all of the following constraints are fulfilled:

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -31,7 +31,8 @@ also used to recalibrate the vision software during a game if the vision expert 
 「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。 +
 The halt command is always followed up by stop.
 
-NOTE: As a rule of thumb, the game should always be halted when humans other than the referees are entering the field.
+NOTE: 経験則として、審判以外の人間がフィールドに立ち入る場合には、試合は常に「ハルト」コマンドで停止されるべきである。 +
+As a rule of thumb, the game should always be halted when humans other than the referees are entering the field.
 
 
 === ボール配置/Ball Placement
@@ -41,7 +42,8 @@ After the game was stopped, the ball must be placed on the appropriate position,
 The automatic ball placement is the preferred way to place the ball at the designated position on the field by the robots of the teams without human interaction.
 If this is not possible, the <<主審/Referee, referee>> places the ball manually.
 
-NOTE: During manual ball placement, the game should be in <<Stop, stop>> to allow robots to prepare for game continuation.
+NOTE: 手動でのボール配置中、ロボットが次の展開に備えるために試合は<<停止/Stop, 「ストップ」>>コマンドにより停止される必要がある。 +
+During manual ball placement, the game should be in <<停止/Stop, stop>> to allow robots to prepare for game continuation.
 
 以下の条件が全て満たされている場合、ボール配置は必要ない: +
 No ball placement is required if all of the following constraints are fulfilled:


### PR DESCRIPTION
[本家Pull Request 57](https://github.com/robocup-ssl/ssl-rules/pull/57)の作業です。 
「ハルト」コマンドと「ストップ」コマンドが使用されるときの判断基準となるような補足事項がルールに追加されます。  
またこっそり原文の誤植が修正されます(`contol` -> `control`)

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
