### PR TITLE
Rules2023/no-pr Division間の相違点: 非常停止がDiv.Aのみであることを記載

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -410,4 +410,5 @@ The automatic <<ボール配置/Ball Placement, ball placement>> procedure is ma
 The <<aimless-kick, aimless kick>> rule only applies to division B.
 * ディヴィジョンAはいくつかの状況における時間切れまでの時間が短い。 +
 Division A has shorter timeouts in some situations
-* <<Emergency stop>> only applies to division A.
+* <<非常停止/Emergency stop, 非常停止>>はディヴィジョンAにのみ適用される。 +
+<<非常停止/Emergency stop, Emergency stop>> only applies to division A.

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -410,3 +410,4 @@ The automatic <<ボール配置/Ball Placement, ball placement>> procedure is ma
 The <<aimless-kick, aimless kick>> rule only applies to division B.
 * ディヴィジョンAはいくつかの状況における時間切れまでの時間が短い。 +
 Division A has shorter timeouts in some situations
+* <<Emergency stop>> only applies to division A.


### PR DESCRIPTION
本家ではPull Requestを介さず、コミット robocup-ssl/ssl-rules@8b712c1db2cdd809164c2d61454215a0234b1d35 でpushされた作業です。 

タイトル通り、Division AとBの相違点として「非常停止ルールはDivision Aのみに適用される」という文言が追加されます。  
ただしこれは後のルール改定 (robocup-ssl/ssl-rules#66) で削除されるために追加された変更事項です。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
