### PR TITLE
Rules2023/63 試合の状態遷移図の追加

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -5,7 +5,7 @@
 Shooting and <<ドリブルデバイス/Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
 
 [appendix]
-== Game States
+== 試合の状態/Game States
 
 [plantuml, target=game-states, format=svg]
 ....

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -10,7 +10,6 @@ Shooting and <<ドリブルデバイス/Dribbling Device, dribbling>> is conside
 [plantuml, target=game-states, format=svg]
 ....
 @startuml
-
 state Halted {
     state Halt {
     }
@@ -51,7 +50,7 @@ FreeKick: One team may kick the ball\nwithin 5 (A) or 10 (B) seconds
 Penalty: Execute a penalty kick within 10 seconds
 Run: Both teams may manipulate the ball
 
-[*] -> Halt: Halt
+[*] -> Halt: (from any state) Halt
 
 Halt --> Stop: Stop
 Stop --> Timeout: Timeout
@@ -72,7 +71,6 @@ Stop --> Run: ForceStart
 Stop --> PreparePenalty: PreparePenalty
 PreparePenalty --> Penalty: NormalStart
 Penalty --> Stop: after 10 seconds
-
 @enduml
 ....
 

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -5,6 +5,78 @@
 Shooting and <<ドリブルデバイス/Dribbling Device, dribbling>> is considered as manipulating the ball, the ball accidentally bouncing off the hull is not.
 
 [appendix]
+== Game States
+
+[plantuml, target=game-states, format=svg]
+....
+@startuml
+
+state Halted {
+    state Halt {
+    }
+    state Timeout {
+    }
+}
+
+state Stopped {
+    state Stop {
+    }
+    state BallPlacement {
+    }
+    state PrepareKickoff {
+    }
+    state PreparePenalty {
+    }
+}
+
+state Running {
+    state Run {
+    }
+    state FreeKick {
+    }
+    state Kickoff {
+    }
+    state Penalty {
+    }
+}
+
+Halt: Robots are not allowed to move
+Timeout: Both teams can do what ever they want
+Stop: Both teams have to keep distance to the ball
+PrepareKickoff: Teams have to move to their sides
+BallPlacement: One team places the ball,\nthe other keeps distance to ball
+PreparePenalty: Keeper on goal line,\nattacker behind ball,\nother robots on legal positions
+Kickoff: One team may kick the ball\nwithin 5 (A) or 10 (B) seconds
+FreeKick: One team may kick the ball\nwithin 5 (A) or 10 (B) seconds
+Penalty: Execute a penalty kick within 10 seconds
+Run: Both teams may manipulate the ball
+
+[*] -> Halt: Halt
+
+Halt --> Stop: Stop
+Stop --> Timeout: Timeout
+Timeout --> Stop: Stop
+
+Stop --> BallPlacement: Ball Placement
+BallPlacement --> Stop: Stop
+
+Stop --> PrepareKickoff: PrepareKickoff
+PrepareKickoff --> Kickoff: NormalStart
+Kickoff --> Run: after x seconds or if ball moved
+
+Stop --> FreeKick: FreeKick
+FreeKick --> Run: after x seconds or if ball moved
+
+Stop --> Run: ForceStart
+
+Stop --> PreparePenalty: PreparePenalty
+PreparePenalty --> Penalty: NormalStart
+Penalty --> Stop: after 10 seconds
+
+@enduml
+....
+
+[appendix]
 == ゲームイベント表/Game Event Table
 ゲームイベント表は、各ゲームイベントとその結果をまとめたものである。また、<<オートレフ/Automatic Referee, オートレフ>>の実装が処理できなければならないものを表記する。 +
 The game event table is a compilation of the different game events and their consequences. It also lists what all <<オートレフ/Automatic Referee, Automatic Referee>> implementations must be capable of handling.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -1,6 +1,7 @@
 == レフェリーコマンド/Referee Commands
 
-An overview of the referee commands and how they interact with the game state, is given in <<Game States>>.
+レフェリーコマンドの概要と、それらが試合の状態とどのように相互作用するかについては「<<試合の状態/Game States, 試合の状態>>」に記載される。 +
+An overview of the referee commands and how they interact with the game state, is given in <<試合の状態/Game States, Game States>>.
 
 === 試合の停止/Stopping The Game
 ==== 停止/Stop

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -1,5 +1,7 @@
 == レフェリーコマンド/Referee Commands
 
+An overview of the referee commands and how they interact with the game state, is given in <<Game States>>.
+
 === 試合の停止/Stopping The Game
 ==== 停止/Stop
 .定義/Definition


### PR DESCRIPTION
[本家Pull Request 63](https://github.com/robocup-ssl/ssl-rules/pull/63)の作業です。  
試合の状態遷移図を追加します。

- [x] cherry-pick
- [x] resolve conflict
- [ ] translation
  - [x] in document
  - [ ] in diagram 
- [ ] review
