### PR TITLE
Rules2023/no-pr travis自動ビルド設定の更新

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,4 @@ script:
   - git config user.email "build-pipeline@travis-ci.org"
   - git add *.html *.pdf
   - git commit -m "Update GitHub Pages"
-  - git push "https://${GH_TOKEN}@${GH_REF}" gh-pages
-
-after_error:
-  - docker logs asciidoc-to-html
-  - docker logs asciidoc-to-pdf
-
-after_failure:
-  - docker logs asciidoc-to-html
-  - docker logs asciidoc-to-pdf
+  - git push "https://oauth2:${GH_TOKEN}@${GH_REF}" gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,4 +25,4 @@ script:
   - git config user.email "build-pipeline@travis-ci.org"
   - git add *.html *.pdf
   - git commit -m "Update GitHub Pages"
-  - git push "https://oauth2:${GH_TOKEN}@${GH_REF}" gh-pages
+  - git push "https://${GH_TOKEN}@${GH_REF}" gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
   - pip install htmldiffer
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -a allow-uri-read -a data-uri sslrules.adoc
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-html htakeuchi/docker-asciidoctor-jp asciidoctor -a allow-uri-read -a data-uri sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-pdf htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
   - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
   - cd $TRAVIS_BUILD_DIR/gh-pages
   - cp ../*.html ../*.pdf .

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,6 @@ install:
 script:
   - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -a allow-uri-read -a data-uri sslrules.adoc
   - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
-
-after_error:
-  - docker logs asciidoc-to-html
-  - docker logs asciidoc-to-pdf
-
-after_failure:
-  - docker logs asciidoc-to-html
-  - docker logs asciidoc-to-pdf
-
-after_script:
   - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
   - cd $TRAVIS_BUILD_DIR/gh-pages
   - cp ../*.html ../*.pdf .
@@ -36,3 +26,11 @@ after_script:
   - git add *.html *.pdf
   - git commit -m "Update GitHub Pages"
   - git push "https://${GH_TOKEN}@${GH_REF}" gh-pages
+
+after_error:
+  - docker logs asciidoc-to-html
+  - docker logs asciidoc-to-pdf
+
+after_failure:
+  - docker logs asciidoc-to-html
+  - docker logs asciidoc-to-pdf


### PR DESCRIPTION
本家ではPull Requestを介さず、以下のコミットで追加された変更事項です。
- robocup-ssl/ssl-rules@1bca576284f3322e1f52e835f4de5af2d7b6c86b  
  `after_error`, `after_failure`セクションの記載順序をファイルの最後尾に移動 
- robocup-ssl/ssl-rules@5ff5b7d08faddc9d0842d0b5e80f8570d7e556be  
  ビルド時の`docker run`に`--name`オプションを追加
- robocup-ssl/ssl-rules@f4ad264dbef3610c8cbfc09d784ea5a468574b3b
  `after_error`, `after_failure`セクションを削除
- robocup-ssl/ssl-rules@6b2498a3c714847c5715ec30ef6721e10eb3d0ab
  robocup-ssl/ssl-rules@f4ad264dbef3610c8cbfc09d784ea5a468574b3b で混入した処理(git push時のURLに`oauth2:`を入れたもの)を差し戻し

ビルド設定の変更だけですが、一部コマンドを日本語環境向けに対応させているためconflictの解消だけしています。

- [x] cherry-pick
- [x] resolve conflict
- [ ] ~~translation~~
- [ ] review
