### PR TITLE
Rules2023/65 イエローカードでロボットが除去されなかった場合の試合続行方法の更新

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -285,16 +285,16 @@ If the yellow card is shown as a result of <<非スポーツマン行為/Unsport
 イエローカードを受け取ると、ペナルティーを受けたチームがフィールドに出場させて良いロボットの数が1台減少する。この減少のあと、チームがフィールドに出場させて良い台数よりも多くのロボットが出場している場合、<<ロボットの交代/Robot Substitution, ロボットを退場>>させなければならない。 +
 Upon receipt of a yellow card, the number of robots allowed on the field for the penalized team decreases by one. If, after this decrease, the team has more robots than permitted on the field, a robot must be <<ロボットの交代/Robot Substitution, taken out>>.
 
-イエローカードは自動的には試合を停止させない。<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>であれば、イエローカードを受けたチームは10秒間で、<<ロボットの交代/Robot Substitution, 自動的にロボットを退場>>させることができる。もしその時間でロボットが退場しなかった場合、ゲームは<<ロボットの交代/Robot Substitution, 手動でのロボット退場>>のため停止させられる。 +
+イエローカードは自動的には試合を停止させない。<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>であれば、イエローカードを受けたチームは10秒間で、<<ロボットの交代/Robot Substitution, 自動的にロボットを退場>>させることができる。もしその時間でロボットが退場しなかった場合、ゲームは<<ロボットの交代/Robot Substitution, 手動でのロボット退場>>のため停止させられ、<<フォーススタート/Force Start, フォーススタート>>で続行される。 +
 もう一方のチームが<<Game Controller, game controller>>に対して申告することでこの10秒の時間制限は無期限に延長され、ゲームは停止されずに続行される。 +
-A yellow card does not lead to a stop automatically. If the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<ロボットの交代/Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>> and continues with a <<Force Start, Forced Start>>.
+A yellow card does not lead to a stop automatically. If the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<ロボットの交代/Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>> and continues with a <<フォーススタート/Force Start, Forced Start>>.
 The 10 seconds can be extended indefinitely by the other team by sending an advance choice to the <<Game Controller, game controller>>.
 
 NOTE: このルールは、イエローカードを受け取った後、ゲームが自動的に停止しない可能性があることを意味する。しかしながら、例えば部品を落とすといった、イエローカードの対象となるファウルがあった場合はゲームは停止する。したがって、これらのファウルのいずれかが発生した場合、チームはロボットを手動で取り除くことができる。 +
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
-NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mの<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上に配置され、相手チームのフリーキックとなる。 +
-NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. However, in the future there will likely be some penalty: If the robot gets manually substituted, the ball is placed on the <<Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
+NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。しかしながら将来的には、(たとえば次に示すような)何らかのペナルティが発生する可能性がある: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mの<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上に配置され、相手チームのフリーキックとなる。 +
+NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. However, in the future there will likely be some penalty: If the robot gets manually substituted, the ball is placed on the <<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -287,14 +287,14 @@ Upon receipt of a yellow card, the number of robots allowed on the field for the
 
 イエローカードは自動的には試合を停止させない。<<インプレイとアウトオブプレイ/Ball In And Out Of Play, インプレイ>>であれば、イエローカードを受けたチームは10秒間で、<<ロボットの交代/Robot Substitution, 自動的にロボットを退場>>させることができる。もしその時間でロボットが退場しなかった場合、ゲームは<<ロボットの交代/Robot Substitution, 手動でのロボット退場>>のため停止させられる。 +
 もう一方のチームが<<Game Controller, game controller>>に対して申告することでこの10秒の時間制限は無期限に延長され、ゲームは停止されずに続行される。 +
-A yellow card does not lead to a stop automatically. If the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<ロボットの交代/Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>>.
+A yellow card does not lead to a stop automatically. If the ball is <<インプレイとアウトオブプレイ/Ball In And Out Of Play, in play>>, the team will have 10 seconds to <<ロボットの交代/Robot Substitution, automatically remove the robot>>. If a robot is not taken out within time, the game is stopped for <<ロボットの交代/Robot Substitution, manual substitution>> and continues with a <<Force Start, Forced Start>>.
 The 10 seconds can be extended indefinitely by the other team by sending an advance choice to the <<Game Controller, game controller>>.
 
 NOTE: このルールは、イエローカードを受け取った後、ゲームが自動的に停止しない可能性があることを意味する。しかしながら、例えば部品を落とすといった、イエローカードの対象となるファウルがあった場合はゲームは停止する。したがって、これらのファウルのいずれかが発生した場合、チームはロボットを手動で取り除くことができる。 +
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
 NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mの<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上に配置され、相手チームのフリーキックとなる。 +
-NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. Thus, the game shall be restarted using a force start. However, in the future (probably 2023) this will change: If the robot gets manually substituted, the ball is placed on the <<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
+NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. However, in the future there will likely be some penalty.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -294,7 +294,7 @@ NOTE: このルールは、イエローカードを受け取った後、ゲー�
 This rule implies that after receiving a yellow card, the game might not be automatically stopped. However, the game will be stopped if the foul that led to the yellow card causes a game stoppage, e.g. dropping parts. Therefore, if one of those fouls occurred, the team is allowed to manually remove the robot.
 
 NOTE: 時間内にロボットを外に出せなかった場合もペナルティーは無い。したがって、ゲームはフォーススタートにより再開する。しかしながら将来的(おそらく2023年)にはこれは変更される: ロボットを手動で取り除いた場合には、ボールは当該チームのディフェンスエリアから1.5mの<<ゴール・トゥ・ゴールライン/Goal-to-Goal Line, ゴール・トゥ・ゴールライン>>上に配置され、相手チームのフリーキックとなる。 +
-NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. However, in the future there will likely be some penalty.
+NOTE: No penalty will be given to the team that couldn't get the robot out of the field in time. However, in the future there will likely be some penalty: If the robot gets manually substituted, the ball is placed on the <<Goal-to-Goal Line, goal-to-goal line>> and 1.5 meters away from the teams defense area and the opposing team gets a free kick.
 
 許可された台数以上のロボットがフィールド上にある間は、そのチームの得点は認められない。 +
 A team cannot score a goal while having more than the allowed number of robots on the field.


### PR DESCRIPTION
[本家Pull Request 65](https://github.com/robocup-ssl/ssl-rules/pull/65)の作業です。  
イエローカードが発行されると試合は続行されたままロボットは自動的に取り除かれる必要があり、これができなかった場合は試合が停止されて手動でロボットを取り除く必要があります。手動でロボットが取り除かれた後に試合がどのように再開されるかが明文化されます(もともとNOTEに「フォーススタートで続行される」とありましたが、本文中にも記載されるようになります)。  
またロボットを自動的に取り除くことができなかった場合のペナルティについて以前から議論されており、現行のルールでは「2023年からは次のような罰則となるだろう」という文言がありました。しかし現時点でも未確定であるため、「将来的にはこのような罰則になるだろう」という表記に改められます。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review
