### PR TITLE
Rules2023/no-pr ビルドコマンドの更新、.gitignore更新

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 # IntelliJ files
 /.idea
-sslrules.html
-sslrules.pdf
+/sslrules.html
+/sslrules.pdf
+/.asciidoctor
+/images/game-states.svg

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
   - pip install htmldiffer
 
 script:
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-html htakeuchi/docker-asciidoctor-jp asciidoctor -a allow-uri-read -a data-uri sslrules.adoc
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-pdf htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-html htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram  -a allow-uri-read -a data-uri sslrules.adoc
+  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-pdf htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram  -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
   - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
   - cd $TRAVIS_BUILD_DIR/gh-pages
   - cp ../*.html ../*.pdf .

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ If you have Docker installed, you can use the AsciiDoctor image that optimized f
 # Pull image once
 docker pull htakeuchi/docker-asciidoctor-jp
 # Build the HTML5 version
-docker run -v $PWD:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -a allow-uri-read sslrules.adoc
+docker run -v $PWD:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram -a allow-uri-read sslrules.adoc
 # Build the PDF version
-docker run -v $PWD:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
+docker run -v $PWD:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
 ```


### PR DESCRIPTION
本家ではPull Requestを介さず、以下のコミットで追加された変更事項です。
- robocup-ssl/ssl-rules@dd6b54adeb2b379b5e52a1dd3591eba616f4b416
  ビルド時の`asciidoctor`ビルドコマンドにオプション`-a asciidoctor-diagram`を追加

ビルド設定の変更だけですが、一部コマンドを日本語環境向けに対応させているためconflictの解消だけしています。

- [x] cherry-pick
- [x] resolve conflict
- [ ] ~~translation~~
- [ ] review