### PR TITLE
Rules2023/67 travis設定ファイルのsyntax更新

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,37 @@
-if: branch = master-jp
-
-sudo: required
-
-language: python
+language: shell
+os: linux
+dist: focal
 
 services:
   - docker
 
-before_install:
-  - mkdir -p output
-  - docker pull htakeuchi/docker-asciidoctor-jp
+env:
+  - DIFF_YEAR=2022
 
-install:
-  - pip install htmldiffer
+stages:
+  - name: build
+    if: branch != master-jp
+  - name: build-publish
+    if: branch = master-jp
 
-script:
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-html htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram  -a allow-uri-read -a data-uri sslrules.adoc
-  - docker run -v $TRAVIS_BUILD_DIR:/documents/ --name asciidoc-to-pdf htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram  -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a allow-uri-read sslrules.adoc
-  - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
-  - cd $TRAVIS_BUILD_DIR/gh-pages
-  - cp ../*.html ../*.pdf .
-  - python ../diffRules.py ./2022/sslrules.html ./sslrules.html > sslrules-diff.html
-  - git config user.name "TravisCI"
-  - git config user.email "build-pipeline@travis-ci.org"
-  - git add *.html *.pdf
-  - git commit -m "Update GitHub Pages"
-  - git push "https://${GH_TOKEN}@${GH_REF}" gh-pages
+jobs:
+  include:
+    - stage: build
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram -a allow-uri-read -a data-uri *.adoc
+        - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram  -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a *.adoc
+    - stage: build-publish
+      script:
+        - cd $TRAVIS_BUILD_DIR
+        - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram -a allow-uri-read -a data-uri *.adoc
+        - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram  -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a *.adoc
+        - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
+        - cd $TRAVIS_BUILD_DIR/gh-pages
+        - cp ../*.html ../*.pdf .
+        - python ../diffRules.py ./${DIFF_YEAR}/sslrules.html ./sslrules.html > sslrules-diff.html
+        - git config user.name "TravisCI"
+        - git config user.email "build-pipeline@travis-ci.org"
+        - git add *.html *.pdf
+        - git commit -m "Update GitHub Pages"
+        - git push "https://${GH_TOKEN}@${GH_REF}" gh-pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
-language: shell
+language: python
 os: linux
 dist: focal
 
 services:
   - docker
-
-env:
-  - DIFF_YEAR=2022
 
 stages:
   - name: build
@@ -22,6 +19,8 @@ jobs:
         - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram -a allow-uri-read -a data-uri *.adoc
         - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor-pdf -r asciidoctor-diagram  -r asciidoctor-pdf-cjk-kai_gen_gothic -a pdf-style=KaiGenGothicJP -a *.adoc
     - stage: build-publish
+      install:
+        - pip install htmldiffer
       script:
         - cd $TRAVIS_BUILD_DIR
         - docker run -v $TRAVIS_BUILD_DIR:/documents/ htakeuchi/docker-asciidoctor-jp asciidoctor -r asciidoctor-diagram -a allow-uri-read -a data-uri *.adoc
@@ -29,7 +28,8 @@ jobs:
         - git clone https://${GH_REF} --single-branch --branch gh-pages $TRAVIS_BUILD_DIR/gh-pages
         - cd $TRAVIS_BUILD_DIR/gh-pages
         - cp ../*.html ../*.pdf .
-        - python ../diffRules.py ./${DIFF_YEAR}/sslrules.html ./sslrules.html > sslrules-diff.html
+        - year="$(ls -1 | grep -E '^[0-9]{4}$' | sort -n | tail -n1)"
+        - python ../diffRules.py ./${year}/sslrules.html ./sslrules.html > sslrules-diff.html
         - git config user.name "TravisCI"
         - git config user.email "build-pipeline@travis-ci.org"
         - git add *.html *.pdf


### PR DESCRIPTION
[本家Pull Request 67](https://github.com/robocup-ssl/ssl-rules/pull/66)の作業、およびその直後にPull Requestを介さず、以下のコミットで追加された変更事項です。

- robocup-ssl/ssl-rules@7befb469641a1f002af8827091139285e61a5b29  
  `htmldiff`がインストールされておらず使用できなかった問題の修正

ビルド設定の変更だけですが、一部コマンドを日本語環境向けに対応させているためconflictの解消だけしています。

- [x] cherry-pick
- [x] resolve conflict
- [ ] ~~translation~~
- [ ] review

#77 の内容を前提とするためDraftとし、#77 マージ後にrebaseしてmergeします。