### PR TITLE
Rules2023/no-pr fix appendix diagram bp to freekick

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -58,6 +58,7 @@ Timeout --> Stop: Stop
 
 Stop --> BallPlacement: Ball Placement
 BallPlacement --> Stop: Stop
+BallPlacement --> FreeKick: Continue
 
 Stop --> PrepareKickoff: PrepareKickoff
 PrepareKickoff --> Kickoff: NormalStart


### PR DESCRIPTION
本家ではPull Requestを介さず、以下のコミットで追加された変更事項です。
- robocup-ssl/ssl-rules@7ccbc00d5466bf40ff041d8dae4169f04e1c19d2 
  状態遷移図においてボール配置 -> フリーキックへの経路(配置成功)がなかったため追加

