### PR TITLE
Rules2023/no-pr 試合状態遷移図: "Run" -> "Stop"への経路を追加

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -71,6 +71,8 @@ Stop --> Run: ForceStart
 Stop --> PreparePenalty: PreparePenalty
 PreparePenalty --> Penalty: NormalStart
 Penalty --> Stop: after 10 seconds
+
+Run --> Stop: Stop
 @enduml
 ....
 


### PR DESCRIPTION
本家ではPull Requestを介さず、以下のコミットで追加された変更事項です。
- robocup-ssl/ssl-rules@cac74f360cc64f885e3299e6e74473ceb8660fba

試合状態遷移図にて、runningな試合がstopコマンドにより停止される経路がなかったためこれが追加されます。
