### PR TITLE
Rules2023/3894e16 ssl-autorefへのリンク削除

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -147,9 +147,6 @@ New automatic referee implementations can be provided, given that the source cod
 The <<ゲームイベント/Game Events, Game Event Table>> shows which game events an automatic referee implementation must be able to detect.
 Individual game events can be disabled completely or in some automatic referee implementations if both teams and the <<技術委員会/Technical Committee, technical committee>> agree.
 
-存在する実装はGithubで確認することができる。: https://github.com/RoboCup-SSL/ssl-autorefs +
-Existing implementations can be found on Github: https://github.com/RoboCup-SSL/ssl-autorefs.
-
 ==== リモコン/Remote Control
 各チームに1台のリモコンが大会運営よりオプションで提供される。
 これは次のようなコマンドを受け付けるものである: +


### PR DESCRIPTION
本家コミット robocup-ssl/ssl-rules@3894e16 の変更です。  
既存のautoref実装一覧のような役割を果たしていた https://github.com/robocup-ssl/ssl-autorefs はアーカイブされ、現在は更新されていないため、ルールからのリンクが削除します。  
個別の(もともとssl-autorefs のリストにあった Tigers Mannheim やER-Force、2023年ごろに増えた RoboTeam Twente による実装などの) autoref 実装は、引き続きそれぞれのリポジトリで開発が続けられます。