### PR TITLE
Rules2024/71 ディヴィジョンA予選でのロボット台数制限

### DIFF
--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -4,6 +4,7 @@
 試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).
 
+ディヴィジョンAの予選段階では例外として、2チームのうち少なくとも一方のチームが希望すれば、ロボットの台数は8台に制限される。 +
 An exception is made during the Division A group phase, where the number of robots is limited to 8 if at least one of the two teams prefers it.
 
 === ハードウェアとソフトウェアの制約/Hardware And Software Constraints

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -4,6 +4,8 @@
 試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).
 
+An exception is made during the Division A group phase, where the number of robots is limited to 8 if at least one of the two teams prefers it.
+
 === ハードウェアとソフトウェアの制約/Hardware And Software Constraints
 <<主審/Referee, 主審>>はチームが規則を満たさない場合には、フィールドからロボットを取り除くように強制することができる。<<技術委員会/Technical Committee, 技術委員会>>の委員もトーナメントのどの時点でもロボットに取り付けられるハードウェアとソフトウェアを確認することができる。 +
 The <<主審/Referee, referee>> may force a team to remove a robot from the field if it does not satisfy the rules. Members of the <<技術委員会/Technical Committee, technical committee>> may also check the hardware and software constraints of robots at any point of the tournament.


### PR DESCRIPTION
[本家Pull Request 71](https://github.com/robocup-ssl/ssl-rules/pull/71)の作業です。  
Division A Group Phase (予選)において、少なくともどちらか一方のチームが望めばロボットの台数を8台に制限することができるようになります。

- [x] cherry-pick
- [ ] ~~resolve conflict~~
- [x] translation
- [ ] review