### PR TITLE
ci: Update filter condition branch to master-jp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,6 @@ workflows:
   docker:
     jobs:
       - build:
-          filters: { branches: { ignore: master } }
+          filters: { branches: { ignore: master-jp } }
       - build_publish:
-          filters: { branches: { only: master } }
+          filters: { branches: { only: master-jp } }


### PR DESCRIPTION
#84 のフォローアップです。  
CI実行条件のブランチ名が`master`になっていましたが、本リポジトリはブランチ名を`master-jp`としているためこれに合わせて更新します。