### PR TITLE
Rules2024/77 フィールドラインとロボット間の距離を示す際のロボットにおける測定点の明確化

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -46,6 +46,7 @@ The field surface will continue for 0.7 meters beyond the <<フィールドラ�
 ラインとラインの間隔はそれぞれの中心から計測される。 +
 The field of play is marked with lines. All lines are 0.01 meters wide and white (paint, spray, white carpet or strong tape). Lines belong to the areas of which they are boundaries.
 Distances between lines are measured from their centers.
+Distances from a robot are measured from its nearest side to the respective measurement point, with an assumed radius of 0.09 m.
 
 ===== フィールドライン/Field Lines
 プレイエリアは4本のラインで定義される。2本の長辺はタッチラインと呼ばれ、2本の短辺はゴールラインと呼ばれる。 +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -43,7 +43,8 @@ The field surface will continue for 0.7 meters beyond the <<フィールドラ�
 
 ==== フィールドのマーキング/Field Markings
 競技フィールドにはラインが引いてある。すべてのラインは太さ0.01mで白色(塗装、スプレー、白色カーペット、または強力なテープなどいずれか)である。エリアの境界を示すラインはエリアの一部である。
-ラインとラインの間隔はそれぞれの中心から計測される。 +
+ラインとラインの間隔はそれぞれの中心から計測される。
+ロボットからの距離は、ロボットの半径が 0.09m であるものとして、ロボットの最も近い辺から各測定点までを計測する。 +
 The field of play is marked with lines. All lines are 0.01 meters wide and white (paint, spray, white carpet or strong tape). Lines belong to the areas of which they are boundaries.
 Distances between lines are measured from their centers.
 Distances from a robot are measured from its nearest side to the respective measurement point, with an assumed radius of 0.09 m.


### PR DESCRIPTION
[本家Pull Request 77](https://github.com/robocup-ssl/ssl-rules/pull/77)の作業です。  
フィールドラインとロボット間の距離を示す際、これまでのルールではロボットのどの点を測定点として用いるかが定義されていませんでした。  
本変更によりこれが明確化されます。

- [x] cherry-pick
- [ ] ~~resolve conflict~~
- [x] translation
- [ ] review