### PR TITLE
Revert "ci: install htmldiffer from github@develop branch, specify file encoding"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a data-uri -a allow-uri-read *.adoc
           docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -a allow-uri-read -a script=cjk -a pdf-theme=default-with-fallback-font *.adoc
       - run: |
-          pip install git+https://github.com/anastasia/htmldiffer.git@develop
+          pip install htmldiffer
           latest_year="$(ls -1 pages | grep -E '^[0-9]{4}$' | sort -n | tail -n1)"
           python ./diffRules.py ./pages/${latest_year}/sslrules.html ./sslrules.html > sslrules-diff.html
       - run: |

--- a/diffRules.py
+++ b/diffRules.py
@@ -1,7 +1,5 @@
-import io, sys
+import sys
 from htmldiffer import diff
-
-sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
 
 try:
     a, b = sys.argv[1:3]
@@ -9,6 +7,6 @@ except ValueError:
     print("htmldiffer: highlight the differences between two html files")
     print("usage: " + sys.argv[0] + " a b")
     sys.exit(1)
-d = diff.HTMLDiffer(html_a=a, html_b=b, encoding='utf-8')
+d = diff.HTMLDiffer(a, b)
 
 print(d.combined_diff)


### PR DESCRIPTION
本PRは以下の変更を差し戻します: https://github.com/kkimurak/ssl-rules-ja/commit/aa88b94e472c3dc88610179e660a81f4773c9532


#84 でCircleCIへの移行に追従しましたが、日本語版リポジトリとして独自の変更 aa88b94e472c3dc88610179e660a81f4773c9532 を加えていました。これは私の手元の環境(日本語Windowsマシン)で動かしていたときに遭遇した文字化けへの対処で、入出力のエンコードをUTF-8と明示してやることで解決を試みるもので、手元の環境では問題が解消していました。  
また差分生成のために使っているPythonライブラリの[`htmldiffer`](https://github.com/anastasia/htmldiffer)で該当する機能(ファイルのエンコーディング指定)が最新のリリース(といっても2017年)に含まれていなかったため、`pip install`でgithubからインストールするようにしていました。

しかしCircleCIに移行したところCIが落ちており(たとえば <https://app.circleci.com/jobs/github/kkimurak/ssl-rules-ja/12>)、この処理が原因であったのではないかと推測されました。また処理時間が異様に長く、本家ルールのCIでは[`pip install`を含めても3秒で完了している](https://app.circleci.com/pipelines/github/RoboCup-SSL/ssl-rules/21/workflows/b4a09386-24a4-4851-9a80-b03aac5061b9/jobs/26?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary)にもかかわらず本リポジトリでは4分かかっています。手元のWindowsで走らせたときもこの程度の差は認められました。
