### PR TITLE
Rules2024/74 ロボット交代条件の一部変更(緩和)

### DIFF
--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -13,7 +13,7 @@ Robots can always be taken in and out during game play without notifying the <<�
 The robot is at least partially inside the <<フィールドの表面/Field Surface, field margin>>.
 . ロボットは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から1mを超えない位置にある。 +
 The robot is at a distance from the <<ハーフウェーライン/Halfway Line, halfway line>> that must not exceed 1 meter.
-. ボールは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から少なくとも2m離れた地点にある。 +
+. ボールはロボットから少なくとも0.5m離れた地点にある。 +
 The ball must be at least 0.5 meters away from the robot.
 
 加えて、要求があればロボットはどの位置からでも以下の手順に従い除去させられる: +

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -14,7 +14,7 @@ The robot is at least partially inside the <<フィールドの表面/Field Surf
 . ロボットは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から1mを超えない位置にある。 +
 The robot is at a distance from the <<ハーフウェーライン/Halfway Line, halfway line>> that must not exceed 1 meter.
 . ボールは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から少なくとも2m離れた地点にある。 +
-The ball must be at least 2 meters away from the <<ハーフウェーライン/Halfway Line, halfway line>>.
+The ball must be at least 0.5 meters away from the robot.
 
 加えて、要求があればロボットはどの位置からでも以下の手順に従い除去させられる: +
 Additionally, robots can be taken out from any position on request using the procedure below:


### PR DESCRIPTION
[本家Pull Request 74](https://github.com/robocup-ssl/ssl-rules/pull/74)の作業です。  
ロボットの自動的な交代を行う際、これまでは条件の一つに「ハーフウェーラインからボールが少なくとも2m以上離れていること」というものがありました。  
本変更によりこの文言が変更され、「(交代対象の)ロボットから少なくとも0.5m離れていること」となります。交代対象のロボットとボールがゴール・トゥ・ゴールラインを挟んでフィールドの反対側にあるような状況で交代が行いやすくなる、実質的な条件緩和です。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review