### PR TITLE
Rules2024/78 ロボット交代回数制限、および罰則の設定

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -250,7 +250,10 @@ The <<主審/Referee, referee>> is encouraged to call fouls if the non-placing t
 NOTE: もしロボットが(たとえば立ち往生を起こした、動作できない、など)干渉を続ける場合、人間の審判はボール配置を止めて手動でボールを配置することが推奨される。 +
 If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.
 
-===== Excessive Robot Substitutions
+===== ロボット交代回数超過/Excessive Robot Substitutions
+チームが自由に行えるロボットの交代権を使い切った場合、それ以降のすべてのロボット交代はファウルとなる。
+試合は相手チームの <<フリーキック/Free Kick, フリーキック>> で再開される。
+もし両チームが同一の<<停止/Stop, ストップゲーム>>中にこのファウルをとられた場合、試合はもとのコマンドで再開される。 +
 If a team has used up their free robot substitution budget, every additional robot substitution is a foul.
-The match is resumed with a <<Free Kick, free kick>> for the opponent team.
-If both teams committed this foul in the same <<Stop, stop>>, the match is resumed with the original command.
+The match is resumed with a <<フリーキック/Free Kick, free kick>> for the opponent team.
+If both teams committed this foul in the same <<停止/Stop, stop>>, the match is resumed with the original command.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -249,3 +249,8 @@ The <<主審/Referee, referee>> is encouraged to call fouls if the non-placing t
 
 NOTE: もしロボットが(たとえば立ち往生を起こした、動作できない、など)干渉を続ける場合、人間の審判はボール配置を止めて手動でボールを配置することが推奨される。 +
 If a robot keeps interfering the ball placement (for example if it is stuck or can not move), the human referee is encouraged to stop the placement and place the ball manually.
+
+===== Excessive Robot Substitutions
+If a team has used up their free robot substitution budget, every additional robot substitution is a foul.
+The match is resumed with a <<Free Kick, free kick>> for the opponent team.
+If both teams committed this foul in the same <<Stop, stop>>, the match is resumed with the original command.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -24,7 +24,7 @@ The <<ハンドラー/Robot Handler, robot handler>> requests robot substitution
 . <<Game Controller, Game Controller>>が次の機会に<<ハルト/Halt, ハルト>>により試合を停止させる。 +
 The <<Game Controller, game controller>> will <<ハルト/Halt, halt>> the game at the next opportunity.
 . <<ハンドラー/Robot Handler, ハンドラー>>は試合が<<ハルト/Halt, ハルト>>により停止している間、必要に応じてフィールドに入りロボットに触れる。 +
-The <<ハンドラー/Robot Handler, robot handler>> may enter the field and touch robots now, as long as the game is still <<ハルト/Halt, halted>>.
+The <<ハンドラー/Robot Handler, robot handler>> may enter the field and touch robots now.
 . <<ハンドラー/Robot Handler, ハンドラー>>はロボットを外に出す +
 The <<ハンドラー/Robot Handler, robot handler>> takes robots out.
 . <<ハンドラー/Robot Handler, ハンドラー>>は交代が完了したら<<主審/Referee, 主審>>に連絡する +
@@ -39,7 +39,10 @@ The maximum allowed number of robots of the team on the field must not be exceed
 
 .用途/Usage
 いかなる理由であってもロボットの交代ができる。交代の回数に制限はない。 +
-Robots can be substituted for any reason. There is no limit on the number of substitutions.
+Robots can be substituted for any reason.
+A substitution grants the team 10 seconds to take robots out. After that time, a new substitution is started.
+Each team has 5 free substitutions per halftime.
+Every additional substitution will result in an <<Excessive Robot Substitutions, excessive robot substitutions foul>> for the team.
 
 ロボットの交代の意思表示は次のようにして行う： +
 A robot substitution intent can be made by:

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -38,11 +38,14 @@ The <<Game Controller Operator, game controller operator>> performs a <<停止/S
 The maximum allowed number of robots of the team on the field must not be exceeded at any time when putting robots in.
 
 .用途/Usage
-いかなる理由であってもロボットの交代ができる。交代の回数に制限はない。 +
+いかなる理由であってもロボットの交代ができる。
+一度の交代につき、チームは10秒間だけロボットを退場させることができる。この時間を超えた場合、新たにロボット交代の時間が開始される。
+各チームはハーフタイムごとに5回まで罰則なくロボットの交代を行うことができる。　
+これ以降のロボット交代は交代ごとに <<ロボット交代回数超過/Excessive Robot Substitutions, ロボット交代回数超過>>の反則となる。+
 Robots can be substituted for any reason.
 A substitution grants the team 10 seconds to take robots out. After that time, a new substitution is started.
 Each team has 5 free substitutions per halftime.
-Every additional substitution will result in an <<Excessive Robot Substitutions, excessive robot substitutions foul>> for the team.
+Every additional substitution will result in an <<ロボット交代回数超過/Excessive Robot Substitutions, excessive robot substitutions foul>> for the team.
 
 ロボットの交代の意思表示は次のようにして行う： +
 A robot substitution intent can be made by:


### PR DESCRIPTION
[本家Pull Request 78](https://github.com/robocup-ssl/ssl-rules/pull/78)の作業です。  
これまではロボットの交代回数に制限がありませんでした。  
本変更によりハーフタイムごとに各チーム5回までは自由に交代可能、それ以降の交代は1回ごとに回数超過の(試合の停止を伴わない)ファウルとして、相手チームにフリーキックが与えられます。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review