### PR TITLE
Rules2024/80 ロボット交代回数超過から再開する際にフリーキックではなくコーナーキックを使用

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -255,5 +255,5 @@ If a robot keeps interfering the ball placement (for example if it is stuck or c
 試合は相手チームの <<フリーキック/Free Kick, フリーキック>> で再開される。
 もし両チームが同一の<<停止/Stop, ストップゲーム>>中にこのファウルをとられた場合、試合はもとのコマンドで再開される。 +
 If a team has used up their free robot substitution budget, every additional robot substitution is a foul.
-The match is resumed with a <<フリーキック/Free Kick, free kick>> for the opponent team.
+The match is resumed with a <<Corner Kick, corner kick>> for the opponent team.
 If both teams committed this foul in the same <<停止/Stop, stop>>, the match is resumed with the original command.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -252,8 +252,8 @@ If a robot keeps interfering the ball placement (for example if it is stuck or c
 
 ===== ロボット交代回数超過/Excessive Robot Substitutions
 チームが自由に行えるロボットの交代権を使い切った場合、それ以降のすべてのロボット交代はファウルとなる。
-試合は相手チームの <<フリーキック/Free Kick, フリーキック>> で再開される。
+試合は相手チームの <<コーナーキック/Corner Kick, コーナーキック>> で再開される。
 もし両チームが同一の<<停止/Stop, ストップゲーム>>中にこのファウルをとられた場合、試合はもとのコマンドで再開される。 +
 If a team has used up their free robot substitution budget, every additional robot substitution is a foul.
-The match is resumed with a <<Corner Kick, corner kick>> for the opponent team.
+The match is resumed with a <<コーナーキック/Corner Kick, corner kick>> for the opponent team.
 If both teams committed this foul in the same <<停止/Stop, stop>>, the match is resumed with the original command.


### PR DESCRIPTION
[本家Pull Request 80](https://github.com/robocup-ssl/ssl-rules/pull/80)の作業です。本翻訳リポジトリ #90 で追加した内容のフォローアップ(微修正)になります。   

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review