### PR TITLE
Rules2024/81 ロボット交代時間の延長

### DIFF
--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -43,7 +43,7 @@ The maximum allowed number of robots of the team on the field must not be exceed
 各チームはハーフタイムごとに5回まで罰則なくロボットの交代を行うことができる。　
 これ以降のロボット交代は交代ごとに <<ロボット交代回数超過/Excessive Robot Substitutions, ロボット交代回数超過>>の反則となる。+
 Robots can be substituted for any reason.
-A substitution grants the team 10 seconds to take robots out. After that time, a new substitution is started.
+A substitution grants the team 20 seconds to take robots out. After that time, a new substitution is started.
 Each team has 5 free substitutions per halftime.
 Every additional substitution will result in an <<ロボット交代回数超過/Excessive Robot Substitutions, excessive robot substitutions foul>> for the team.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -39,7 +39,7 @@ The maximum allowed number of robots of the team on the field must not be exceed
 
 .用途/Usage
 いかなる理由であってもロボットの交代ができる。
-一度の交代につき、チームは10秒間だけロボットを退場させることができる。この時間を超えた場合、新たにロボット交代の時間が開始される。
+一度の交代につき、チームは20秒間だけロボットを退場させることができる。この時間を超えた場合、新たにロボット交代の時間が開始される。
 各チームはハーフタイムごとに5回まで罰則なくロボットの交代を行うことができる。　
 これ以降のロボット交代は交代ごとに <<ロボット交代回数超過/Excessive Robot Substitutions, ロボット交代回数超過>>の反則となる。+
 Robots can be substituted for any reason.


### PR DESCRIPTION
[本家Pull Request 81](https://github.com/robocup-ssl/ssl-rules/pull/81)の作業です。ロボット交代1回あたりの上限時間が10秒から20秒に延長されます。

- [x] cherry-pick
- [ ] ~~resolve conflict~~
- [x] translation
- [ ] review