### PR TITLE
Rules2024/83 ペナルティーキック開始時におけるキーパー位置の明確化

### DIFF
--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -205,7 +205,7 @@ The ball is placed by the human referee on the <<ペナルティーマーク/Pen
 . <<ペナルティーキック/Penalty Kick, ペナルティー>>コマンドが発行された時: +
 When the <<ペナルティーキック/Penalty Kick, penalty>> command is issued:
 .. 守備側のキーパーはゴールラインまで移動し、それに触れ続けなければならない。 +
-The defending keeper has to move to the goal line and keep touching it.
+The defending keeper has to move to the goal line between the goal posts and keep touching the goal line.
 .. 攻撃側のロボット1台はボールに近付くことが許されるが、このときボールに触れてはならない。 +
 One attacking robot is allowed to approach the ball but not allowed to touch the ball.
 .. ペナルティーキックの手順の間、その他の全てのロボットはペナルティーキックの手順に干渉しないよう、ボールから1m以上後方にいなければならない。 +

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -204,7 +204,7 @@ The procedure of a penalty kick is as follows:
 The ball is placed by the human referee on the <<ペナルティーマーク/Penalty Mark, penalty mark>>.
 . <<ペナルティーキック/Penalty Kick, ペナルティー>>コマンドが発行された時: +
 When the <<ペナルティーキック/Penalty Kick, penalty>> command is issued:
-.. 守備側のキーパーはゴールラインまで移動し、それに触れ続けなければならない。 +
+.. 守備側のキーパーはゴールポスト間のゴールラインまで移動し、ゴールラインに触れ続けなければならない。 +
 The defending keeper has to move to the goal line between the goal posts and keep touching the goal line.
 .. 攻撃側のロボット1台はボールに近付くことが許されるが、このときボールに触れてはならない。 +
 One attacking robot is allowed to approach the ball but not allowed to touch the ball.


### PR DESCRIPTION
[本家Pull Request 83](https://github.com/robocup-ssl/ssl-rules/pull/83)の作業です。  

ペナルティーキックの準備段階において、守備側キーパーはゴールライン上にいなければならない旨のルールはこれまでもありました。  
一方でSSL世界Discordにて、ssl-game-controller が「守備側キーパーがゴールポストの間のゴールラインに触れているか」を確認をしている、との指摘がありました。  

本PRはこれに対応し、ルールの文言に「ゴールポストの間」の一文を付け足すものです。  

- [x] cherry-pick
- [ ] ~~resolve conflict~~
- [x] translation
- [ ] review

optional

- [ ] Find the source code for the ssl-game-controller or autoref implementations that check if the keeper is on the goal line between the goalposts.
