### PR TITLE
Rules2025/88 タイムアウト中のロボット手動移動禁止

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -243,6 +243,8 @@ As a result, the time needed for a match is much greater than the playing time.
 タイムアウトを取りたい時、<<ハンドラー/Robot Handler, ハンドラー>>は主審に確認をとらなければならない。タイムアウトは<<概要/Overview, 休憩>>のように扱われ、両チームとも自らのソフトウェアとハードウェアの修正を行うことが許可されている(「<<自律性/Autonomy, 自律性>>」を参照)。 +
 The <<ハンドラー/Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<概要/Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<自律性/Autonomy,Autonomy>>).
 
+Any robot that has been physically interacted with during a timeout must be taken out of the field. It can be brought in again, also during the same timeout, via the area outlined in <<Robot Substitution, Robot Substitution>>.
+
 どちらのチームも競技開始から4回までのタイムアウトが割り当てられている。すべてのタイムアウトの合計は300秒まで許されている。タイムアウトはstop game中のみ取得することができる。時間は<<Game Controller Operator, game controller operator>>によって監視と記録がされている。 +
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game
 stoppage. The time is monitored and recorded by the <<Game Controller Operator, game controller operator>>.

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -243,7 +243,8 @@ As a result, the time needed for a match is much greater than the playing time.
 タイムアウトを取りたい時、<<ハンドラー/Robot Handler, ハンドラー>>は主審に確認をとらなければならない。タイムアウトは<<概要/Overview, 休憩>>のように扱われ、両チームとも自らのソフトウェアとハードウェアの修正を行うことが許可されている(「<<自律性/Autonomy, 自律性>>」を参照)。 +
 The <<ハンドラー/Robot Handler, robot handler>> has to ask the referee for a timeout. Timeouts are handled like <<概要/Overview, breaks>>, meaning that both teams are allowed to make modifications to their software and hardware (see <<自律性/Autonomy,Autonomy>>).
 
-Any robot that has been physically interacted with during a timeout must be taken out of the field. It can be brought in again, also during the same timeout, via the area outlined in <<Robot Substitution, Robot Substitution>>.
+タイムアウト中に物理的な接触があったロボットは、フィールド外に除去されなければならない。これは除去したものと同一のタイムアウト中であっても、「<<ロボットの交代/Robot Substitution, ロボットの交代>>」に記載されたエリアからフィールド内に投入することができる。 +
+Any robot that has been physically interacted with during a timeout must be taken out of the field. It can be brought in again, also during the same timeout, via the area outlined in <<ロボットの交代/Robot Substitution, Robot Substitution>>.
 
 どちらのチームも競技開始から4回までのタイムアウトが割り当てられている。すべてのタイムアウトの合計は300秒まで許されている。タイムアウトはstop game中のみ取得することができる。時間は<<Game Controller Operator, game controller operator>>によって監視と記録がされている。 +
 Each team is allocated 4 timeouts at the beginning of the match. A total of 300 seconds is allowed for all timeouts. Timeouts may only be taken during a game

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -73,5 +73,5 @@ NOTE: Bluetoothによる通信は周波数チャンネルを固定にできな�
 Bluetooth is not allowed since it cannot be fixed to frequency channels.
 
 ==== 自律性/Autonomy
-ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、<<概要/Overview, 休憩>>や<<タイムアウト/Timeouts, タイムアウト>>中以外に、システムに対して一切の情報を入力することはできない。このルールを無視することは、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなす。 +
+ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、<<概要/Overview, 休憩>>や<<タイムアウト/Timeouts, タイムアウト>>中以外に、システムに対して一切の情報を入力することはできない。加えて、「<<ロボットの交代/Robot Substitution, ロボットの交代>>」で述べられているフィールド外への除去、もしくはフィールド内への投入を除いて、試合中のいかなる段階においてもロボットは手動で動かされてはならない。このルールを無視することは、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなす。 +
 The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Additionally, robots may not be manually moved during any phase of the match, except for moving robots out of the field, or into the field as described in <<Robot Substitution, Robot Substitution>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -74,4 +74,4 @@ Bluetooth is not allowed since it cannot be fixed to frequency channels.
 
 ==== 自律性/Autonomy
 ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、<<概要/Overview, 休憩>>や<<タイムアウト/Timeouts, タイムアウト>>中以外に、システムに対して一切の情報を入力することはできない。このルールを無視することは、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなす。 +
-The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.
+The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Additionally, robots may not be manually moved during any phase of the match, except for moving robots out of the field, or into the field as described in <<Robot Substitution, Robot Substitution>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.


### PR DESCRIPTION
[本家Pull Request 88](https://github.com/robocup-ssl/ssl-rules/pull/88)の作業です。  

タイムアウト時にロボットに触れる場合はそのロボットをフィールド外に出す必要があります。ただし同一タイムアウト中であっても、指定されたエリアからであればフィールド内にロボットを投入することができます。  

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review