### PR TITLE
CI: asciidcotor ビルドコマンドの修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: |
           docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a data-uri -a allow-uri-read *.adoc
-          docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -a allow-uri-read -a script=cjk -a pdf-theme=default-with-fallback-font *.adoc
+          docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -a allow-uri-read -a scripts=cjk -a pdf-theme=default-with-fallback-font *.adoc
   build_publish:
     machine:
       image: ubuntu-2204:current
@@ -19,7 +19,7 @@ jobs:
       - checkout
       - run: |
           docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor -r asciidoctor-diagram -a data-uri -a allow-uri-read *.adoc
-          docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -a allow-uri-read -a script=cjk -a pdf-theme=default-with-fallback-font *.adoc
+          docker run -v $(pwd):/documents/ -u $(id -u) asciidoctor/docker-asciidoctor asciidoctor-pdf -r asciidoctor-diagram -a allow-uri-read -a scripts=cjk -a pdf-theme=default-with-fallback-font *.adoc
       - run: |
           pip install htmldiffer
           latest_year="$(ls -1 pages | grep -E '^[0-9]{4}$' | sort -n | tail -n1)"


### PR DESCRIPTION
CIでの自動ビルドコマンドに誤字がありましたので修正します。  
`asciidoctor`コマンドにオプション `-a scripts=cjk` と設定することで中国語・日本語・韓国語といった言語で改行位置が改善されるなどの効果が期待できます。しかしビルドコマンドが `-a script=cjk` (script末尾のsが欠落)となっており、この機能が働いていませんでした。