### PR TITLE
Rules2024/86 ロボット外装色

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -143,6 +143,9 @@ The <<主審/Referee, referee>> asks the <<ハンドラー/Robot Handler, robot 
 ただし、両チームが同じ色を希望した場合は、主審は色を任意に割り当てる。この場合、可能であれば、両チームは前半終了後と延長戦の前半終了後に色を入れ替える。 +
 However, if both teams prefer the same color, the referee assigns the colors by chance. In this case, the teams switch the colors after the first half of the match as well as after the first half of the overtime if applicable.
 
+==== Choosing Robot Hull Colors
+The <<Hull Color of Robots, robot hull color>> (dark or bright) should match the <<Choosing Team Colors, team's color>>. The blue team uses the dark hulls, while the yellow team uses light hulls. If teams switch color during the game, they must switch also hull colors.
+
 ==== 陣地とキックオフの選択/Choosing Side And Kick-Off
 <<主審/Referee, 主審>>は両チームの<<ハンドラー/Robot Handler, ハンドラー>>と一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時の<<キックオフ/Kick-Off, キックオフ>>を行う。 +
 The <<主審/Referee, referee>> tosses a coin with both <<ハンドラー/Robot Handler, robot handlers>>. The winning team chooses the goal it will attack in the first half of the match. The other team takes the <<キックオフ/Kick-Off, kick-off>> to start the match.

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -143,8 +143,9 @@ The <<主審/Referee, referee>> asks the <<ハンドラー/Robot Handler, robot 
 ただし、両チームが同じ色を希望した場合は、主審は色を任意に割り当てる。この場合、可能であれば、両チームは前半終了後と延長戦の前半終了後に色を入れ替える。 +
 However, if both teams prefer the same color, the referee assigns the colors by chance. In this case, the teams switch the colors after the first half of the match as well as after the first half of the overtime if applicable.
 
-==== Choosing Robot Hull Colors
-The <<Hull Color of Robots, robot hull color>> (dark or bright) should match the <<Choosing Team Colors, team's color>>. The blue team uses the dark hulls, while the yellow team uses light hulls. If teams switch color during the game, they must switch also hull colors.
+==== ロボット外装色の選択/Choosing Robot Hull Colors
+<<ロボット外装の色/Hull Color of Robots, ロボット外装の色>> (暗もしくは明)は<<チームカラーの選択/Choosing Team Colors, チームカラー>>と一致する必要がある。チームカラーが青であるチームは暗配色の外装を、黄であるチームは明配色の外装を使用する。試合中にチームカラーが変更される場合は、外装の色もまた変更しなければならない。 +
+The <<ロボット外装の色/Hull Color of Robots, robot hull color>> (dark or bright) should match the <<チームカラーの選択/Choosing Team Colors, team's color>>. The blue team uses the dark hulls, while the yellow team uses light hulls. If teams switch color during the game, they must switch also hull colors.
 
 ==== 陣地とキックオフの選択/Choosing Side And Kick-Off
 <<主審/Referee, 主審>>は両チームの<<ハンドラー/Robot Handler, ハンドラー>>と一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時の<<キックオフ/Kick-Off, キックオフ>>を行う。 +

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -25,6 +25,21 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければならない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
+==== Hull Color of Robots
+To ensure clarity and effective identification during gameplay, the following rules apply to the coloring of robot hulls:
+
+Bright and dark color scheme:
+
+* All robots from a team must have interchangeable hull colors: one bright and one dark.
+* These two colors must be the same for all robots in a team.
+* The color must vertically cover at least 6 cm of the robot's maximum height.
+
+Coverage requirements:
+
+* The robot hull must not be reflective to avoid interfering with the vision system.
+* The robot hull must avoid colors close to the ones used at <<Vision Pattern, vision pattern>> and <<Ball, ball>>. 
+* Colors must adhere properly and remain durable to prevent dropping or peeling during the match. If the color cover drops, it will be penalized accordingly (see <<Tipping Over Or Dropping Parts>>).
+
 ==== ドリブルデバイス/Dribbling Device
 ボールを積極的にスピンさせてボールをロボットに接触し続けさせるためのドリブルデバイスは以下の条件を満たす場合のみ許可される。 +
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -25,20 +25,32 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければならない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
-==== Hull Color of Robots
+==== ロボット外装の色/Hull Color of Robots
+試合中の明瞭さと効果的な識別を確保するために、ロボット外装の色付けには次のルールが適用される: +
 To ensure clarity and effective identification during gameplay, the following rules apply to the coloring of robot hulls:
 
+暗配色と明配色: +
 Bright and dark color scheme:
 
-* All robots from a team must have interchangeable hull colors: one bright and one dark.
-* These two colors must be the same for all robots in a team.
-* The color must vertically cover at least 6 cm of the robot's maximum height.
 
+* チームの全ロボットは、明配色と暗配色それぞれ1種類の交換可能な外装を備えなければならない。 +
+All robots from a team must have interchangeable hull colors: one bright and one dark.
+* この2色はチーム内の全ロボットについて同一でなければならない。 +
+These two colors must be the same for all robots in a team.
+* その色はロボットの最大高さのうち、少なくとも6cmを垂直方向に覆わなくてはならない。 +
+The color must vertically cover at least 6 cm of the robot's maximum height.
+
+被覆率の要求仕様: +
 Coverage requirements:
 
-* The robot hull must not be reflective to avoid interfering with the vision system.
-* The robot hull must avoid colors close to the ones used at <<Vision Pattern, vision pattern>> and <<Ball, ball>>. 
-* Colors must adhere properly and remain durable to prevent dropping or peeling during the match. If the color cover drops, it will be penalized accordingly (see <<Tipping Over Or Dropping Parts>>).
+* visionシステムへの干渉を防ぐため、ロボット外装は反射性であってはならない。 +
+The robot hull must not be reflective to avoid interfering with the vision system.
+* ロボット外装の色は<<Vision Pattern, Visionパターン>>や<<ボール/Ball, ボール>>に用いられる色と近しい色であってはならない。 +
+The robot hull must avoid colors close to the ones used at <<Vision Pattern, vision pattern>> and <<ボール/Ball, ball>>. 
+* 試合中に落ちたりはがれたりしないように、色は適切に付着し、耐久性を維持しなければならない。カラーカバーが落下した場合は、それに応じた罰則が課せられる (「<<転倒や部品の脱落/Tipping Over Or Dropping Parts, 転倒や部品の脱落>>」を参照)。 +
+Colors must adhere properly and remain durable to prevent dropping or peeling during the match. If the color cover drops, it will be penalized accordingly (see <<転倒や部品の脱落/Tipping Over Or Dropping Parts, Tipping Over Or Dropping Parts>>).
+
+NOTE: (訳者注記) ここで「外装(hull)」とは「ガワ」「カバー」「シェル」などと呼称される場合もある、ロボット外観のうち上面をのぞいた側面を覆っている箇所を指す。
 
 ==== ドリブルデバイス/Dribbling Device
 ボールを積極的にスピンさせてボールをロボットに接触し続けさせるためのドリブルデバイスは以下の条件を満たす場合のみ許可される。 +
@@ -89,4 +101,4 @@ Bluetooth is not allowed since it cannot be fixed to frequency channels.
 
 ==== 自律性/Autonomy
 ロボットの装備は完全に自律していなくてはならない。試合中、人間のオペレーターは、<<概要/Overview, 休憩>>や<<タイムアウト/Timeouts, タイムアウト>>中以外に、システムに対して一切の情報を入力することはできない。加えて、「<<ロボットの交代/Robot Substitution, ロボットの交代>>」で述べられているフィールド外への除去、もしくはフィールド内への投入を除いて、試合中のいかなる段階においてもロボットは手動で動かされてはならない。このルールを無視することは、<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなす。 +
-The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Additionally, robots may not be manually moved during any phase of the match, except for moving robots out of the field, or into the field as described in <<Robot Substitution, Robot Substitution>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.
+The robotic equipment has to be fully autonomous. Human operators are not permitted to enter any information to the system during a match, except in <<概要/Overview, breaks>> or during a <<タイムアウト/Timeouts, timeout>>. Additionally, robots may not be manually moved during any phase of the match, except for moving robots out of the field, or into the field as described in <<ロボットの交代/Robot Substitution, Robot Substitution>>. Disregarding this rule is considered <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>.


### PR DESCRIPTION
[本家Pull Request 86](https://github.com/robocup-ssl/ssl-rules/pull/86)の作業です。  

ロボットの外装の色を、チームカラーに合わせて設定する必要があります。チームカラーが変わる場合は外装色も変える必要があります。  
また外装は比反射性で、色はロボット高さ方向のうち6cmを覆う必要があります。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review