### PR TITLE
Rules2025/91 ファウル"相手ディフェンスエリアへの極端な接近”の調整

### DIFF
--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -93,15 +93,23 @@ red card>>.
 ==== 試合の停止を伴うファウル/Stopping Fouls
 このセクションにあるファウルは試合を<<停止/Stop, 停止>>させ、反則が発生した時点でボールがあった位置からの<<フリーキック/Free Kick, フリーキック>>で再開する。 +
 Fouls in this section cause the game to <<停止/Stop, stop>> and then resume
-with a <<フリーキック/Free Kick, free kick>> from the position where the ball was
+with a <<フリーキック/Free Kick, free kick>> for the opposite team from the position where the ball was
 located when the foul began happening.
 
 ===== ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area
 <<試合の再開/Resuming The Game, 試合を再開する>>前の、<<停止/Stop, 停止>>、<<フリーキック/Free Kick, フリーキック>>の間、すべてのロボットは相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から少なくとも0.2m以上離れていなければならない。 +
-During <<停止/Stop, stop>> and <<フリーキック/Free Kick, free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
+During <<停止/Stop, stop>> and <<フリーキック/Free Kick, free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>,
+all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ロボットが相手ディフェンスエリアから離れるため、2秒間の猶予が設けられる。 +
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.
+
+The game is immediately halted after every second such foul committed by the same team.
+
+NOTE: If the foul is committed during a <<Free Kick, free kick>>, the game is still stopped.
+The grace period is restarted after the first foul of the same team.
+Both fouls count towards the foul counter.
+There are no individual fouls per robot.
 
 ===== プッシング/Pushing
 あるロボットが相手のロボットに外力を加えて押していて、両方のロボットがボールもしくは互いに接触している(たとえば互いのロボットが相手のロボットの方向に移動している)時、これはプッシングの反則となる。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -98,8 +98,7 @@ located when the foul began happening.
 
 ===== ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area
 <<試合の再開/Resuming The Game, 試合を再開する>>前の、<<停止/Stop, 停止>>、<<フリーキック/Free Kick, フリーキック>>の間、すべてのロボットは相手の<<ディフェンスエリア/Defense Area, ディフェンスエリア>>から少なくとも0.2m以上離れていなければならない。 +
-During <<停止/Stop, stop>> and <<フリーキック/Free Kick, free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>,
-all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
+During <<停止/Stop, stop>> and <<フリーキック/Free Kick, free kicks>>, before the ball <<試合の再開/Resuming The Game, has entered play>>, all robots have to keep at least 0.2 meters distance to the opponent <<ディフェンスエリア/Defense Area, defense area>>.
 
 ロボットが相手ディフェンスエリアから離れるため、2秒間の猶予が設けられる。 +
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -104,9 +104,9 @@ all robots have to keep at least 0.2 meters distance to the opponent <<ディフ
 ロボットが相手ディフェンスエリアから離れるため、2秒間の猶予が設けられる。 +
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.
 
-The game is immediately halted after every second such foul committed by the same team.
+The game is immediately halted after the second such foul committed by the same team while the game is stopped or during a <<Free Kick, free kick>>, before the ball has entered play.
 
-NOTE: If the foul is committed during a <<Free Kick, free kick>>, the game is still stopped.
+NOTE: If the first foul is committed during a <<Free Kick, free kick>>, the game is still stopped regularly.
 The grace period is restarted after the first foul of the same team.
 Both fouls count towards the foul counter.
 There are no individual fouls per robot.

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -91,7 +91,7 @@ red card>>.
 
 
 ==== 試合の停止を伴うファウル/Stopping Fouls
-このセクションにあるファウルは試合を<<停止/Stop, 停止>>させ、反則が発生した時点でボールがあった位置からの<<フリーキック/Free Kick, フリーキック>>で再開する。 +
+このセクションにあるファウルは試合を<<停止/Stop, 停止>>させ、反則が発生した時点でボールがあった位置から相手チームの<<フリーキック/Free Kick, フリーキック>>で再開する。 +
 Fouls in this section cause the game to <<停止/Stop, stop>> and then resume
 with a <<フリーキック/Free Kick, free kick>> for the opposite team from the position where the ball was
 located when the foul began happening.
@@ -103,9 +103,14 @@ During <<停止/Stop, stop>> and <<フリーキック/Free Kick, free kicks>>, b
 ロボットが相手ディフェンスエリアから離れるため、2秒間の猶予が設けられる。 +
 There is a grace period of 2 seconds for the robots to move away from the opponent defense area.
 
-The game is immediately halted after the second such foul committed by the same team while the game is stopped or during a <<Free Kick, free kick>>, before the ball has entered play.
+試合が停止(stop)状態もしくは<<フリーキック/Free Kick, フリーキック>>中で、インプレイになる前に同じチームによる2度目の反則があった場合は、試合は直ちに停止(halt)される。 +
+The game is immediately halted after the second such foul committed by the same team while the game is stopped or during a <<フリーキック/Free Kick, free kick>>, before the ball has entered play.
 
-NOTE: If the first foul is committed during a <<Free Kick, free kick>>, the game is still stopped regularly.
+NOTE: 最初の反則が<<フリーキック/Free Kick, フリーキック>>中に発生した場合、試合は通常通りに停止(stop)される。
+猶予時間は同チームによる最初の反則後から再開される。
+いずれの反則も、ファウルのカウンターを進める。
+ロボットごとに個別の反則を取られることはない。 +
+If the first foul is committed during a <<フリーキック/Free Kick, free kick>>, the game is still stopped regularly.
 The grace period is restarted after the first foul of the same team.
 Both fouls count towards the foul counter.
 There are no individual fouls per robot.


### PR DESCRIPTION
[本家Pull Request 91](https://github.com/robocup-ssl/ssl-rules/pull/91)の作業です。  

ロボットの相手ディフェンスエリアへの極端な接近/Robot Too Close To Opponent Defense Area を調整します。  

ストップゲーム中およびフリーキック中、各ロボットは相手チームのディフェンスエリアから少なくとも0.2m以上離れる必要があります。  
ロボットがこの制限エリアから離れるための猶予時間(2秒間)が設けられていたものの、本反則は試合の停止を伴う(non-stopping foul)ため、たとえばロボットがスタックして動けなくなっている場合などは2秒ごとに反則を取られてstopがかかり、改めてフリーキックがコールされるというループが発生することになっていました。  
詳細な議論は[本家issue 76](https://github.com/robocup-ssl/ssl-rules/issues/76)を参照してください。

ルールを調整し、本ファウルが同じチームにより連続して2回発生した場合、試合はhaltされるようになります。イエローカードなどの基準となるファウル回数カウンターは(これまで通り)反則ごとにカウントアップされます。ロボットごとに反則を取られることはありません。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review