### PR TITLE
 Rules2025/98 ロボット外装色ルールのリファクタリング

### DIFF
--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -144,8 +144,8 @@ The <<主審/Referee, referee>> asks the <<ハンドラー/Robot Handler, robot 
 However, if both teams prefer the same color, the referee assigns the colors by chance. In this case, the teams switch the colors after the first half of the match as well as after the first half of the overtime if applicable.
 
 ==== ロボット外装色の選択/Choosing Robot Hull Colors
-チームは試合前に<<ロボット外装の色/Hull Color of Robots, ロボット外装の色>> (暗もしくは明)を選択してよい。両チームが同じ色を選択した場合、<<主審/Referee, 主審>>は試合開始前に任意に色を割り当てる。選択された外装色は試合を通して使用されなければならない。 +
-Teams are encouraged to choose their preferred <<ロボット外装の色/Hull Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<主審/Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
+チームは試合前に<<ロボットの色/Color of Robots, ロボット外装の色>> (暗もしくは明)を選択してよい。両チームが同じ色を選択した場合、<<主審/Referee, 主審>>は試合開始前に任意に色を割り当てる。選択された外装色は試合を通して使用されなければならない。 +
+Teams are encouraged to choose their preferred <<Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
 
 ==== 陣地とキックオフの選択/Choosing Side And Kick-Off
 <<主審/Referee, 主審>>は両チームの<<ハンドラー/Robot Handler, ハンドラー>>と一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時の<<キックオフ/Kick-Off, キックオフ>>を行う。 +

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -145,7 +145,7 @@ However, if both teams prefer the same color, the referee assigns the colors by 
 
 ==== ロボット外装色の選択/Choosing Robot Hull Colors
 チームは試合前に<<ロボットの色/Color of Robots, ロボット外装の色>> (暗もしくは明)を選択してよい。両チームが同じ色を選択した場合、<<主審/Referee, 主審>>は試合開始前に任意に色を割り当てる。選択された外装色は試合を通して使用されなければならない。 +
-Teams are encouraged to choose their preferred <<Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
+Teams are encouraged to choose their preferred <<ロボットの色/Color of Robots, robot hull color>> (dark or bright) before the match. If both teams choose the same color, the <<主審/Referee, referee>> assigns the colors by chance before the game starts. The selected hull color must be used throughout the game.
 
 ==== 陣地とキックオフの選択/Choosing Side And Kick-Off
 <<主審/Referee, 主審>>は両チームの<<ハンドラー/Robot Handler, ハンドラー>>と一緒にコイントスを行う。コイントスの勝者が前半戦で攻めるゴールを選ぶ。もう一方のチームが前半戦開始時の<<キックオフ/Kick-Off, キックオフ>>を行う。 +

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -53,8 +53,6 @@ Robot sides must avoid colors similar to those used in the <<Vision Pattern, vis
 * 剥脱や剥離を防ぐため、ロボットの色は適切に塗布され、試合を通じて耐久性がなければならない。試合中にカラーが剥がれた場合、罰則が適用される(「<<転倒や部品の脱落/Tipping Over Or Dropping Parts, 転倒や部品の脱落>>」を参照)。 +
 Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<転倒や部品の脱落/Tipping Over Or Dropping Parts, Tipping Over Or Dropping Parts>>).
 
-NOTE: (訳者注記) ここで「外装(hull)」とは「ガワ」「カバー」「シェル」などと呼称される場合もある、ロボット外観のうち上面をのぞいた側面を覆っている箇所を指す。
-
 ==== ドリブルデバイス/Dribbling Device
 ボールを積極的にスピンさせてボールをロボットに接触し続けさせるためのドリブルデバイスは以下の条件を満たす場合のみ許可される。 +
 Dribbling devices that actively exert spin on the ball, which keep the ball in contact with the robot are permitted under certain conditions:

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -25,30 +25,25 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければならない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
-==== ロボット外装の色/Hull Color of Robots
+==== ロボットの色/Color of Robots
 試合中の明瞭さと効果的な識別を確保するために、ロボット外装の色付けには次のルールが適用される: +
-To ensure clarity and effective identification during gameplay, the following rules apply to the coloring of robot hulls:
+To ensure clear identification during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply:
 
 暗配色と明配色: +
-Bright and dark color scheme:
+Color scheme requirements:
 
-
-* チームの全ロボットは、明配色と暗配色それぞれ1種類の交換可能な外装を備えなければならない。 +
-All robots from a team must have interchangeable hull colors: one bright and one dark.
-* この2色はチーム内の全ロボットについて同一でなければならない。 +
-These two colors must be the same for all robots in a team.
-* その色はロボットの最大高さのうち、少なくとも6cmを垂直方向に覆わなくてはならない。 +
-The color must vertically cover at least 6 cm of the robot's maximum height.
+* Robots must have distinctive coloring covering at least 20% of the robot's surrounding area (bottom and top surfaces do not count).
+* The color must be partially visible from all sides.
+* All robots from a team must have interchangeable colors: one bright and one dark.
+* These two colors must be consistent across all robots on the same team.
 
 被覆率の要求仕様: +
-Coverage requirements:
+Design and durability requirements:
 
-* visionシステムへの干渉を防ぐため、ロボット外装は反射性であってはならない。 +
-The robot hull must not be reflective to avoid interfering with the vision system.
-* ロボット外装の色は<<Vision Pattern, Visionパターン>>や<<ボール/Ball, ボール>>に用いられる色と近しい色であってはならない。 +
-The robot hull must avoid colors close to the ones used at <<Vision Pattern, vision pattern>> and <<ボール/Ball, ball>>. 
-* 試合中に落ちたりはがれたりしないように、色は適切に付着し、耐久性を維持しなければならない。カラーカバーが落下した場合は、それに応じた罰則が課せられる (「<<転倒や部品の脱落/Tipping Over Or Dropping Parts, 転倒や部品の脱落>>」を参照)。 +
-Colors must adhere properly and remain durable to prevent dropping or peeling during the match. If the color cover drops, it will be penalized accordingly (see <<転倒や部品の脱落/Tipping Over Or Dropping Parts, Tipping Over Or Dropping Parts>>).
+* Teams may use creative patterns to distinguish their robots from other teams.
+* Robot color must not be reflective, and the top surface should be black to avoid vision system interference.
+* Robot sides must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
+* Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
 
 NOTE: (訳者注記) ここで「外装(hull)」とは「ガワ」「カバー」「シェル」などと呼称される場合もある、ロボット外観のうち上面をのぞいた側面を覆っている箇所を指す。
 

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -26,24 +26,32 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
 ==== ロボットの色/Color of Robots
-試合中の明瞭さと効果的な識別を確保するために、ロボット外装の色付けには次のルールが適用される: +
+試合中に明確に識別できるようにするため、ロボットは視覚的に相手チームと区別できる必要がある。以下のルールが適用される: +
 To ensure clear identification during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply:
 
-暗配色と明配色: +
+配色の要求仕様: +
 Color scheme requirements:
 
-* Robots must have distinctive coloring covering at least 20% of the robot's surrounding area (bottom and top surfaces do not count).
-* The color must be partially visible from all sides.
-* All robots from a team must have interchangeable colors: one bright and one dark.
-* These two colors must be consistent across all robots on the same team.
+* ロボットの周囲20%以上に特徴的なカラーリングが施されていること(底面と上面はカウントしない)。 +
+Robots must have distinctive coloring covering at least 20% of the robot's surrounding area (bottom and top surfaces do not count).
+* カラーリングは各面から部分的にでも視認できること。 +
+The color must be partially visible from all sides.
+* チームのすべてのロボットは、明色と暗色の交換が可能であること。 +
+All robots from a team must have interchangeable colors: one bright and one dark.
+* これらの2色は、同一チーム内のすべてのロボットについて統一されていること。 +
+These two colors must be consistent across all robots on the same team.
 
-被覆率の要求仕様: +
+デザインと耐久性の要求仕様: +
 Design and durability requirements:
 
-* Teams may use creative patterns to distinguish their robots from other teams.
-* Robot color must not be reflective, and the top surface should be black to avoid vision system interference.
-* Robot sides must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<Ball, ball>>.
-* Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<Tipping Over Or Dropping Parts>>).
+* チームは他チームのロボットと区別するために、独創的なパターンを使用してもよい。 +
+Teams may use creative patterns to distinguish their robots from other teams.
+* ロボットの色は反射性であってはならず、また上面はvisionシステムの干渉を避けるため黒色であるべきである。 +
+Robot color must not be reflective, and the top surface should be black to avoid vision system interference.
+* ロボットの側面色は<<Vision Pattern, Visionパターン>>や<<ボール/Ball, ボール>>に使用されているものと似た色を避けなければならない。 +
+Robot sides must avoid colors similar to those used in the <<Vision Pattern, vision pattern>> and <<ボール/Ball, ball>>.
+* 剥脱や剥離を防ぐため、ロボットの色は適切に塗布され、試合を通じて耐久性がなければならない。試合中にカラーが剥がれた場合、罰則が適用される(「<<転倒や部品の脱落/Tipping Over Or Dropping Parts, 転倒や部品の脱落>>」を参照)。 +
+Colors must be properly applied and durable throughout the match to prevent peeling or detachment. If color covering detaches during play, penalties will apply (see <<転倒や部品の脱落/Tipping Over Or Dropping Parts, Tipping Over Or Dropping Parts>>).
 
 NOTE: (訳者注記) ここで「外装(hull)」とは「ガワ」「カバー」「シェル」などと呼称される場合もある、ロボット外観のうち上面をのぞいた側面を覆っている箇所を指す。
 


### PR DESCRIPTION
[本家Pull Request 98](https://github.com/robocup-ssl/ssl-rules/pull/98)の作業です。  

ロボット外装色について以下の制限緩和が行われます。

- 「チームを区別するためのカラーリング」が占める面積を「高さ方向の60%」から「(上面と底面を除く)表面積の20%」に変更
- チームを区別するための「創造的なパターン(creative patters)」の許可

また外装色がはがれた場合には「転落や部品の脱落/Tipping Over Or Dropping Parts」の反則となり、罰則が適用される旨が明記されます。

訳者注記として「hull」が指し示す内容の説明を記載していましたが、以上によりルールが整理されたため本PRで削除します。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review