### PR TITLE
ハルト/Halt 表記を Halt に統一

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -93,7 +93,7 @@ The information shown in this table here may be incomplete. Please read the sect
 || <<ダブルタッチ/Double Touch, ATTACKER_DOUBLE_TOUCHED_BALL>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<停止/Stop>> -> <<フリーキック/Free Kick>> | no | auto referee
 
 | 5+| *ボールがフィールド外に出た時/Ball Leaving the Field*
-|| <<得点/Scoring Goals, POSSIBLE_GOAL>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<ハルト/Halt>> | no | auto referee
+|| <<得点/Scoring Goals, POSSIBLE_GOAL>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<Halt>> | no | auto referee
 || <<タッチラインとの交差/Touch Line Crossing, BALL_LEFT_FIELD_TOUCH_LINE>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<停止/Stop>> -> <<フリーキック/Free Kick>> | no | auto referee
 || <<ゴールラインとの交差/Goal Line Crossing, BALL_LEFT_FIELD_GOAL_LINE>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<停止/Stop>> -> <<フリーキック/Free Kick>> | no | auto referee
 || <<aimless-kick, AIMLESS_KICK>> | <<インプレイとアウトオブプレイ/Ball In And Out Of Play, ball in play>> | <<停止/Stop>> -> <<フリーキック/Free Kick>> | no | auto referee
@@ -167,10 +167,10 @@ during <<ボール配置/Ball Placement, Ball Placement>>
 || <<ロボットの交代/Robot Substitution, BOT_SUBSTITUTION>> 
 | <<停止/Stop, 停止>>中 +
 during <<停止/Stop, Stop>>
-| (次の停止時に)<<ハルト/Halt, ハルト>>、次いで<<停止/Stop, 停止>> +
-<<ハルト/Halt, Halt>> (after next stoppage), then <<停止/Stop, Stop>> | no | remote control
+| (次の停止時に)<<Halt>>、次いで<<停止/Stop, 停止>> +
+<<Halt>> (after next stoppage), then <<停止/Stop, Stop>> | no | remote control
 || <<チャレンジフラッグ/Challenge Flags, CHALLENGE_FLAG>> | 常時/always | - | no | remote control
-|| <<非常停止/Emergency stop, EMERGENCY_STOP>> | 常時/always | <<ハルト/Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
+|| <<非常停止/Emergency stop, EMERGENCY_STOP>> | 常時/always | <<Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
 
 6+| *手動/Manual*
 || <<得点/Scoring Goals, GOAL>> | - | <<停止/Stop>> -> <<キックオフ/Kick-Off>> | no | human referee

--- a/chapters/gamestructure.adoc
+++ b/chapters/gamestructure.adoc
@@ -237,8 +237,8 @@ unlimited
 
 |===
 
-競技のタイマーは両チームとも<<ボールの操作/Ball Manipulation,ボールを操作する>>ことが許されない場合に一時停止される。これには<<停止/Stop, ストップゲーム>>、<<ハルト/Halt, ハルト>>、<<キックオフ/Kick-Off, キックオフ>>と<<ペナルティーキック/Penalty Kick,ペナルティーキック>>の準備時間が含まれる。さらに<<ボール配置/Ball Placement, ボール配置中>>もタイマーは一時停止される。 +
-The match timer is paused whenever no team is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. This includes <<停止/Stop, stop>>, <<ハルト/Halt, halt>> and the preparation states of <<キックオフ/Kick-Off, kick-off>> and <<ペナルティーキック/Penalty Kick, penalty kick>>. Additionally, it is paused during <<ボール配置/Ball Placement, ball placement>>.
+競技のタイマーは両チームとも<<ボールの操作/Ball Manipulation,ボールを操作する>>ことが許されない場合に一時停止される。これには<<停止/Stop, ストップゲーム>>、<<Halt>>、<<キックオフ/Kick-Off, キックオフ>>と<<ペナルティーキック/Penalty Kick,ペナルティーキック>>の準備時間が含まれる。さらに<<ボール配置/Ball Placement, ボール配置中>>もタイマーは一時停止される。 +
+The match timer is paused whenever no team is allowed to <<ボールの操作/Ball Manipulation, manipulate the ball>>. This includes <<停止/Stop, stop>>, <<Halt, halt>> and the preparation states of <<キックオフ/Kick-Off, kick-off>> and <<ペナルティーキック/Penalty Kick, penalty kick>>. Additionally, it is paused during <<ボール配置/Ball Placement, ball placement>>.
 
 NOTE: この結果、試合に必要な時間は競技時間よりもはるかに長くなる。 +
 As a result, the time needed for a match is much greater than the playing time.

--- a/chapters/refereecommands.adoc
+++ b/chapters/refereecommands.adoc
@@ -13,32 +13,33 @@ NOTE: ボールが高速に転がる場合、特にストップ中はロボッ�
 If the ball moves very quickly, it is hard to always keep the required distance to the ball, especially since the speed of the robots is limited during stop. Therefore, it is sufficient if it is obvious to the referee that the robots try their best to follow the distance rule.
 
 .用途/Usage
-「ストップ」コマンドはボールが(ゴールを含む)<<フィールドライン/Field Lines, フィールドライン>>を超えた後や反則が発生した後に競技を一時停止するために使われ、ハルトやタイムアウト、自動的なボール配置の再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく配置することができる。 +
+「ストップ」コマンドはボールが(ゴールを含む)<<フィールドライン/Field Lines, フィールドライン>>を超えた後や反則が発生した後に競技を一時停止するために使われ、Haltやタイムアウト、自動的なボール配置の再開を準備するために使われる。ロボットの速度制限とボールとの最小距離によって、主審や副審がボールを安全に干渉なく配置することができる。 +
 The stop command is used to pause the game after the ball crossed the <<フィールドライン/Field Lines, field lines>> (including goals) or an offense occurred as well as to prepare the start or resumption of the game after halt, timeouts and automatic ball placement. The robot speed limit and the minimum distance to the ball allow the referee or assistant referee to place the ball safely and without interference.
 
 NOTE: (訳者注記)一般的に「ストップゲーム」もしくは単に「ストップ」と呼称されることが多い。
 
-==== ハルト/Halt
+==== Halt
 .定義/Definition
-「ハルト」コマンドが発行されると、すべてのロボットは動作を停止し、<<ボールの操作/Ball Manipulation, ボールを操作>>してはならない。 +
+「Halt」コマンドが発行されると、すべてのロボットは動作を停止し、<<ボールの操作/Ball Manipulation, ボールを操作>>してはならない。 +
 When the halt command is issued, no robot is allowed to move or <<ボールの操作/Ball Manipulation, manipulate the ball>>.
 
 ロボットが減速するために2秒間の猶予がある。 +
 There is a grace period of 2 seconds for the robots to brake.
 
 .用途/Usage
-(例えばロボットが制御不能になった時など)緊急事態が発生した時に主審は「ハルト」コマンドで試合を中断させることができる。また、Vision expertが必要と判断した場合にはVisionソフトウェアの再キャリブレーションにも使われ、主審が同意する場合には<<ロボットの交代/Robot Substitution, ロボットの交代>>にも使われる。さらに、主審は自由に「ハルト」コマンドを発行することができる。 +
+(例えばロボットが制御不能になった時など)緊急事態が発生した時に主審は「Halt」コマンドで試合を中断させることができる。また、Vision expertが必要と判断した場合にはVisionソフトウェアの再キャリブレーションにも使われ、主審が同意する場合には<<ロボットの交代/Robot Substitution, ロボットの交代>>にも使われる。さらに、主審は自由に「Halt」コマンドを発行することができる。 +
 The halt command allows the referee to interrupt the game immediately whenever an emergency occurs (for example when a robot gets out of control). It is
 also used to recalibrate the vision software during a game if the vision expert considers it necessary and the referee agrees and for <<ロボットの交代/Robot Substitution, robot substitution>>. Additionally, the referee is free to issue the halt command at will.
 
-「ハルト」コマンドの後は常に「ストップ」コマンドが送信される。試合が続行される前に、各チームに十分な準備時間が与えられる。<<Game Controller, Game Controller>>は「ハルト」コマンドから最大で10秒間だけ待機するが、ロボットの準備ができていれば試合は続行できる。 +
+「Halt」コマンドの後は常に「ストップ」コマンドが送信される。試合が続行される前に、各チームに十分な準備時間が与えられる。<<Game Controller, Game Controller>>は「Halt」コマンドから最大で10秒間だけ待機するが、ロボットの準備ができていれば試合は続行できる。 +
 The halt command is always followed up by stop.
 Enough preparation time should be given to teams, before the game is continued.
 The <<Game Controller, game controller>> will wait for up to 10 seconds after a halt command, but the game can be continued if robots are prepared already.
 
-NOTE: 経験則として、審判以外の人間がフィールドに立ち入る場合には、試合は常に「ハルト」コマンドで停止されるべきである。 +
+NOTE: 経験則として、審判以外の人間がフィールドに立ち入る場合には、試合は常に「Halt」コマンドで停止されるべきである。 +
 As a rule of thumb, the game should always be halted when humans other than the referees are entering the field.
 
+NOTE: 発音記号は `/hˈɔːlt/` (ホルト、ホールト) である。誤りではあるが、日本ではローマ字読みで「ハルト」と発音される場合もある。
 
 === ボール配置/Ball Placement
 .定義/Definition
@@ -282,8 +283,8 @@ see <<ダブルタッチ/Double Touch, double touch>> for the rationale of the 0
 ==== イエローカード/Yellow Card
 .定義/Definition
 
-イエローカードが非スポーツマン行為の結果として示された場合、主審は直ちに試合を<<ハルト/Halt, 中断>>することができる。この場合、もう片方のチームのフリーキックで試合が継続される。 +
-If the yellow card is shown as a result of <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>, the referee may decide to immediately <<ハルト/Halt, halt>> the match. In this case, the match continues with a free kick for the other team.
+イエローカードが非スポーツマン行為の結果として示された場合、主審は直ちに試合を<<Halt, 中断>>することができる。この場合、もう片方のチームのフリーキックで試合が継続される。 +
+If the yellow card is shown as a result of <<非スポーツマン行為/Unsporting Behavior, unsporting behavior>>, the referee may decide to immediately <<Halt, halt>> the match. In this case, the match continues with a free kick for the other team.
 
 イエローカードを受け取ると、ペナルティーを受けたチームがフィールドに出場させて良いロボットの数が1台減少する。この減少のあと、チームがフィールドに出場させて良い台数よりも多くのロボットが出場している場合、<<ロボットの交代/Robot Substitution, ロボットを退場>>させなければならない。 +
 Upon receipt of a yellow card, the number of robots allowed on the field for the penalized team decreases by one. If, after this decrease, the team has more robots than permitted on the field, a robot must be <<ロボットの交代/Robot Substitution, taken out>>.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -21,9 +21,9 @@ Additionally, robots can be taken out from any position on request using the pro
 
 . 任意の時点で<<ハンドラー/Robot Handler, ハンドラー>>がロボットの交代を要求する。 +
 The <<ハンドラー/Robot Handler, robot handler>> requests robot substitution at any time.
-. <<Game Controller, Game Controller>>が次の機会に<<ハルト/Halt, ハルト>>により試合を停止させる。 +
-The <<Game Controller, game controller>> will <<ハルト/Halt, halt>> the game at the next opportunity.
-. <<ハンドラー/Robot Handler, ハンドラー>>は試合が<<ハルト/Halt, ハルト>>により停止している間、必要に応じてフィールドに入りロボットに触れる。 +
+. <<Game Controller, Game Controller>>が次の機会に<<Halt>>により試合を停止させる。 +
+The <<Game Controller, game controller>> will <<Halt, halt>> the game at the next opportunity.
+. <<ハンドラー/Robot Handler, ハンドラー>>は試合が<<Halt>>により停止している間、必要に応じてフィールドに入りロボットに触れる。 +
 The <<ハンドラー/Robot Handler, robot handler>> may enter the field and touch robots now.
 . <<ハンドラー/Robot Handler, ハンドラー>>はロボットを外に出す +
 The <<ハンドラー/Robot Handler, robot handler>> takes robots out.
@@ -59,8 +59,8 @@ A team software by sending a request to the <<Game Controller, game controller>>
 . <<Game Controller, game controller>>は当該チームに許された最大ロボット数を超えていないかを確認し(例えばチームが<<イエローカード/Yellow Card, イエロー>>か<<レッドカード/Red Card, レッドカード>>を受け取ったあと等)、リクエストを処理する。 +
 The <<Game Controller, game controller>> itself if a team exceeds the maximum number of robots (for example after a team receives a <<イエローカード/Yellow Card, yellow>> or <<レッドカード/Red Card, red card>>).
 
-片方のチームの交代の意図のために試合がハルトされた場合、少なくとも一台のロボットが除去されなければならない。交代のために試合がハルトされていない場合に限り交代の意図を取り消すことができる。 +
+片方のチームの交代の意図のために試合がHaltされた場合、少なくとも一台のロボットが除去されなければならない。交代のために試合がHaltされていない場合に限り交代の意図を取り消すことができる。 +
 If the game was halted due to a substitution intent by a team, at least one robot must be taken out by this team. A substitution intent can be revoked unless the game was not already halted for substitution.
 
-ボール配置後、試合が継続する直前にどちらかのチームがロボットを交代する意思がある場合、<<Game Controller, game controller>>は自動的に試合を<<ハルト/Halt, ハルト>>する。 +
-If a robot substitution intent for either team is present just before the game would continue after ball placement, the <<Game Controller, game controller>> automatically <<ハルト/Halt, halts>> the game.
+ボール配置後、試合が継続する直前にどちらかのチームがロボットを交代する意思がある場合、<<Game Controller, game controller>>は自動的に試合を<<Halt>>する。 +
+If a robot substitution intent for either team is present just before the game would continue after ball placement, the <<Game Controller, game controller>> automatically <<Halt, halts>> the game.


### PR DESCRIPTION
ルール中の "Halt" について「ハルト/Halt」と表記していましたが、これは正しい発音表記ではなく、実際は「ホルト」「ホールト」といった発音になります。  
そもそも名詞的に扱われるルール上の表現を日本語に訳すことにも無理がありますので、発音についての注記を追加したうえで「Halt」表記に統一します。