### PR TITLE
Rules2026/103 ロボット交代用エリアの拡充

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -94,7 +94,8 @@ The penalty mark defines the point from which a team executes a penalty kick aga
 ゴールはそれぞれのゴールラインの中央に配置し、しっかりと固定されなければならない。ゴールは高さ0.16mの2枚の垂直なサイドウォールと1枚の垂直なリヤウォールがつながって構成されている。ゴールの内側は、ボールの衝撃を吸収し偏向速度を減じるための材質 - 例えば発泡材など - で覆われる必要がある。ゴールの内壁は白色で、外壁と角および上面は黒色で塗装される。 +
 Goals must be placed on the center of each goal line and anchored securely to the field surface. They consist of two 0.16 meters high vertical side walls joined at the back by a 0.16 meters high vertical rear wall. The inner face of the goal has to be covered with an energy absorbing material such as foam to help absorb ball impacts and lessen the speed of deflections. The inner goal walls are white, the outer goal walls, edges, and tops are black.
 
-サイドウォールの間の距離はディヴィジョンAであれば1.8mでディヴィジョンBであれば1mで、奥行は0.18mである。ゴールウォールの厚さは0.02mでゴールラインと接している。ただし、フィールドラインやフィールドに対して侵入したり重なったりしないようにしている。<<goal-detail-a, 図3>>と<<goal-detail-b, 図4>>にディヴィジョンAとディヴィジョンBの詳細をそれぞれ示す。 +
+サイドウォールの間の距離はディヴィジョンAであれば1.8mでディヴィジョンBであれば1mで、奥行は0.18mである。ゴールウォールの厚さは0.02mでゴールラインと接している。ただし、フィールドラインやフィールドに対して侵入したり重なったりしないようにしている。<<goal-detail-a, 図3>>と<<goal-detail-b, 図4>>にディヴィジョンAとディヴィジョンBの詳細をそれぞれ示す。
+ゴールのサイドウォールはフィールド外周の壁まで伸びている。 +
 The distance between the side walls is 1.8 meters for division A and 1 meter for division B, and the goal is 0.18 meters deep. The goal walls are 0.02 meters thick and touch the goal line, but do not overlap or encroach on the field lines or the field. <<goal-detail-a, Figure 3>> and <<goal-detail-b, figure 4>> show these details for division A and division B respectively.
 The goal side walls extend to the outside wall.
 

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -35,11 +35,17 @@ https://www.jfa.jp/documents/pdf/soccer/lawsofthegame_201819.pdf)
 
 ==== フィールドの表面/Field Surface
 競技フィールドの表面は緑色のフェルトマットかカーペットである。カーペット下の床は固く平坦で水平である。 +
-The playing surface is green felt mat or carpet. The floor under the carpet is level, flat, and hard.
+The playing surface is a green felt mat or carpet. The floor under the carpet is level, flat, and hard.
 
 フィールドはすべての<<フィールドライン/Field Lines, フィールドライン>>から0.7mまで続いている。フィールドの外周0.4mは高さ0.1mの黒色のフェンスでロボットエリアと分離され、<<主審/Referee, 主審>>と<<副審/Assistant Referee, 副審>>が通行するエリアとして使用される。 残りの0.3mはフィールドのマージンである。 +
-The field surface will continue for 0.7 meters beyond the <<フィールドライン/Field Lines, field lines>> on all sides. The outer 0.4 meters of this runoff area, separated from the robot area by a 0.1 meters tall black wall, is used as a designated walking area for the <<主審/Referee, referee>> and the <<副審/Assistant Referee, assistant referee>>. The remaining 0.3 meters are the field margins.
+The field surface continues for at least 0.7 meters beyond the <<フィールドライン/Field Lines, field lines>> on all sides. The field margin extends from the field lines to the surrounding walls:
 
+* Division A: 0.3 meters along the touch lines, 0.6 meters behind the goal lines.
+* Division B: 0.3 meters on all sides.
+
+Any area beyond the walls is used as a designated walking area for the <<主審/Referee, referee>> and the <<副審/Assistant Referee, assistant referee>>.
+
+The extra field margin behind each goal line in Division A is used for <<Robot Substitution>>.
 
 ==== フィールドのマーキング/Field Markings
 競技フィールドにはラインが引いてある。すべてのラインは太さ0.01mで白色(塗装、スプレー、白色カーペット、または強力なテープなどいずれか)である。エリアの境界を示すラインはエリアの一部である。
@@ -86,6 +92,7 @@ Goals must be placed on the center of each goal line and anchored securely to th
 
 サイドウォールの間の距離はディヴィジョンAであれば1.8mでディヴィジョンBであれば1mで、奥行は0.18mである。ゴールウォールの厚さは0.02mでゴールラインと接している。ただし、フィールドラインやフィールドに対して侵入したり重なったりしないようにしている。<<goal-detail-a, 図3>>と<<goal-detail-b, 図4>>にディヴィジョンAとディヴィジョンBの詳細をそれぞれ示す。 +
 The distance between the side walls is 1.8 meters for division A and 1 meter for division B, and the goal is 0.18 meters deep. The goal walls are 0.02 meters thick and touch the goal line, but do not overlap or encroach on the field lines or the field. <<goal-detail-a, Figure 3>> and <<goal-detail-b, figure 4>> show these details for division A and division B respectively.
+The goal side walls extend to the outside wall.
 
 NOTE: 図中の数値はミリメートル表示の距離である +
 The numbers in the figures below show the distances in millimeters.

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -37,15 +37,19 @@ https://www.jfa.jp/documents/pdf/soccer/lawsofthegame_201819.pdf)
 競技フィールドの表面は緑色のフェルトマットかカーペットである。カーペット下の床は固く平坦で水平である。 +
 The playing surface is a green felt mat or carpet. The floor under the carpet is level, flat, and hard.
 
-フィールドはすべての<<フィールドライン/Field Lines, フィールドライン>>から0.7mまで続いている。フィールドの外周0.4mは高さ0.1mの黒色のフェンスでロボットエリアと分離され、<<主審/Referee, 主審>>と<<副審/Assistant Referee, 副審>>が通行するエリアとして使用される。 残りの0.3mはフィールドのマージンである。 +
+フィールドはすべての<<フィールドライン/Field Lines, フィールドライン>>から少なくとも0.7mまで続いている。フィールドのマージンはフィールドラインからフィールドを囲む壁まで広がっている: +
 The field surface continues for at least 0.7 meters beyond the <<フィールドライン/Field Lines, field lines>> on all sides. The field margin extends from the field lines to the surrounding walls:
 
-* Division A: 0.3 meters along the touch lines, 0.6 meters behind the goal lines.
-* Division B: 0.3 meters on all sides.
+* ディヴィジョン A: タッチラインに沿って0.3m、ゴールラインから後ろに0.6m +
+  Division A: 0.3 meters along the touch lines, 0.6 meters behind the goal lines.
+* ディヴィジョン B: すべての辺から0.3m +
+  Division B: 0.3 meters on all sides.
 
+壁の外側のエリアは<<主審/Referee, 主審>>と<<副審/Assistant Referee, 副審>>が通行するエリアとして使用される。 +
 Any area beyond the walls is used as a designated walking area for the <<主審/Referee, referee>> and the <<副審/Assistant Referee, assistant referee>>.
 
-The extra field margin behind each goal line in Division A is used for <<Robot Substitution>>.
+ディヴィジョンAにおけるゴール後ろ側のフィールドのマージンは <<ロボットの交代/Robot Substitution, ロボットの交代>> に使用される。 +
+The extra field margin behind each goal line in Division A is used for <<ロボットの交代/Robot Substitution, Robot Substitution>>.
 
 ==== フィールドのマーキング/Field Markings
 競技フィールドにはラインが引いてある。すべてのラインは太さ0.01mで白色(塗装、スプレー、白色カーペット、または強力なテープなどいずれか)である。エリアの境界を示すラインはエリアの一部である。

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -2,7 +2,9 @@
 
 === ロボットの台数/Number Of Robots
 試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
-A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper. Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).
+A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper.
+Robots in the <<goal-substitution-area, Goal Substitution Area>> do not count towards this limit.
+Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).
 
 ディヴィジョンAの予選段階では例外として、2チームのうち少なくとも一方のチームが希望すれば、ロボットの台数は8台に制限される。 +
 An exception is made during the Division A group phase, where the number of robots is limited to 8 if at least one of the two teams prefers it.

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -1,7 +1,9 @@
 == ロボット/Robots
 
 === ロボットの台数/Number Of Robots
-試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
+試合は1台のキーパーを含んだディヴィジョンAなら11台以下、ディヴィジョンBなら6台以下のロボットを使用する2つのチームで行われる。
+<<goal-substitution-area, ゴール側交代エリア>> にあるロボットはこの制限に計上しない。
+試合中に審判がロボットを識別できるように、各ロボットにはVision patternに従って明確に番号が与えられていなければならない。ゴールキーパーのIDは試合が始まる前に指定されていなければならない(「<<ゴールキーパーのIDの選択/Choosing Keeper Id,ゴールキーパーのIDの選択>>」を参照)。 +
 A match is played by two teams, with each team consisting of not more than 11 robots in division A and not more than 6 robots in division B, one of which may be the keeper.
 Robots in the <<goal-substitution-area, Goal Substitution Area>> do not count towards this limit.
 Each robot must be clearly numbered according to its vision pattern so that the referee can identify it during the match. The id of the keeper must be chosen before the match starts (see <<ゴールキーパーのIDの選択/Choosing Keeper Id, Choosing Keeper ID>>).

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -4,13 +4,18 @@
 
 [[goal-substitution-area]]
 ==== ゴール側交代エリア/Goal Substitution Area (Division A only)
+ロボットが自陣側ゴールラインから少なくとも 0.3m フィールド外に出ているとき、ロボットはゴール側交代エリア内にあるとみなされる。 +
 A robot is considered to be in the Goal Substitution Area if it is at least 0.3 meters outside the field, behind its own goal line.
 
+ロボットは試合中、ゴール側交代エリアにいてよい。
+これらは自由に移動することができ、以下のルールに従う必要がある: +
 Robots are allowed to remain in the Goal Substitution Area while the game is running.
 They are allowed to move freely and must comply with the following rules:
 
-* Minimum ball distance during <<停止/Stop, stop>> or <<フリーキック/Free Kick, free kick>>
-* Must not interfere with <<ボール配置/Ball Placement, ball placement>>
+* <<停止/Stop, 「停止」>>中、もしくは<<フリーキック/Free Kick, フリーキック>>中におけるボールとの最小距離制約を満たすこと +
+Minimum ball distance during <<停止/Stop, stop>> or <<フリーキック/Free Kick, free kick>>
+* <<ボール配置/Ball Placement, ボール配置>>に干渉しないこと +
+Must not interfere with <<ボール配置/Ball Placement, ball placement>>
 
 [[center-substitution-area]]
 ==== センター交代エリア/Center Substitution Area
@@ -28,7 +33,8 @@ The <<ハンドラー/Robot Handler, robot handler>> should prefer to use long s
 以下のすべての条件に適合する場合は、ゲーム中のいつでも<<主審/Referee, 主審>>に確認を取ることなくロボットを投入もしくは除去することができる: +
 Robots can always be taken in and out during game play without notifying the <<主審/Referee, referee>> if all the following conditions are met:
 
-. The robot is in its team's substitution area.
+. ロボットが各チームの交代エリアにある。 +
+The robot is in its team's substitution area.
 . ボールはロボットから少なくとも0.5m離れた地点にある。 +
 The ball must be at least 0.5 meters away from the robot.
 

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -22,7 +22,7 @@ Must not interfere with <<ボール配置/Ball Placement, ball placement>>
 ロボットが少なくとも部分的にフィールドのマージン内にあり、かつ<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から最大1mの距離にあれば、ロボットはセンター交代エリア内にあるとみなされる。 +
 A robot is considered to be in the Center Substitution Area if it is at least partially inside the field margin and at a distance of at most 1 meter from the <<ハーフウェーライン/Halfway Line, halfway line>>.
 
-=== Rules
+=== ルール/Rules
 .定義/Definition
 ロボットはそれぞれのチームの<<ハンドラー/Robot Handler, ハンドラー>>によって交代される。他のいかなるチームメンバーもロボットを出し入れすることは許可されない。 +
 Robots are substituted by the <<ハンドラー/Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -1,20 +1,21 @@
 == ロボットの交代/Robot Substitution
 
-=== Substitution Areas
+=== 交代エリア/Substitution Areas
 
 [[goal-substitution-area]]
-==== Goal Substitution Area (Division A only)
+==== ゴール側交代エリア/Goal Substitution Area (Division A only)
 A robot is considered to be in the Goal Substitution Area if it is at least 0.3 meters outside the field, behind its own goal line.
 
 Robots are allowed to remain in the Goal Substitution Area while the game is running.
 They are allowed to move freely and must comply with the following rules:
 
-* Minimum ball distance during <<Stop, stop>> or <<Free Kick, free kick>>
-* Must not interfere with <<Ball Placement, ball placement>>
+* Minimum ball distance during <<停止/Stop, stop>> or <<フリーキック/Free Kick, free kick>>
+* Must not interfere with <<ボール配置/Ball Placement, ball placement>>
 
 [[center-substitution-area]]
-==== Center Substitution Area
-A robot is considered to be in the Center Substitution Area if it is at least partially inside the field margin and at a distance of at most 1 meter from the <<Halfway Line, halfway line>>.
+==== センター交代エリア/Center Substitution Area
+ロボットが少なくとも部分的にフィールドのマージン内にあり、かつ<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から最大1mの距離にあれば、ロボットはセンター交代エリア内にあるとみなされる。 +
+A robot is considered to be in the Center Substitution Area if it is at least partially inside the field margin and at a distance of at most 1 meter from the <<ハーフウェーライン/Halfway Line, halfway line>>.
 
 === Rules
 .定義/Definition

--- a/chapters/substitution.adoc
+++ b/chapters/substitution.adoc
@@ -1,4 +1,22 @@
 == ロボットの交代/Robot Substitution
+
+=== Substitution Areas
+
+[[goal-substitution-area]]
+==== Goal Substitution Area (Division A only)
+A robot is considered to be in the Goal Substitution Area if it is at least 0.3 meters outside the field, behind its own goal line.
+
+Robots are allowed to remain in the Goal Substitution Area while the game is running.
+They are allowed to move freely and must comply with the following rules:
+
+* Minimum ball distance during <<Stop, stop>> or <<Free Kick, free kick>>
+* Must not interfere with <<Ball Placement, ball placement>>
+
+[[center-substitution-area]]
+==== Center Substitution Area
+A robot is considered to be in the Center Substitution Area if it is at least partially inside the field margin and at a distance of at most 1 meter from the <<Halfway Line, halfway line>>.
+
+=== Rules
 .定義/Definition
 ロボットはそれぞれのチームの<<ハンドラー/Robot Handler, ハンドラー>>によって交代される。他のいかなるチームメンバーもロボットを出し入れすることは許可されない。 +
 Robots are substituted by the <<ハンドラー/Robot Handler, robot handler>> of the respective team. No other team member is allowed to take robots out or put robots in.
@@ -9,10 +27,7 @@ The <<ハンドラー/Robot Handler, robot handler>> should prefer to use long s
 以下のすべての条件に適合する場合は、ゲーム中のいつでも<<主審/Referee, 主審>>に確認を取ることなくロボットを投入もしくは除去することができる: +
 Robots can always be taken in and out during game play without notifying the <<主審/Referee, referee>> if all the following conditions are met:
 
-. ロボットは少なくとも部分的に<<フィールドの表面/Field Surface, フィールドのマージン部分>>にある。 +
-The robot is at least partially inside the <<フィールドの表面/Field Surface, field margin>>.
-. ロボットは<<ハーフウェーライン/Halfway Line, ハーフウェーライン>>から1mを超えない位置にある。 +
-The robot is at a distance from the <<ハーフウェーライン/Halfway Line, halfway line>> that must not exceed 1 meter.
+. The robot is in its team's substitution area.
 . ボールはロボットから少なくとも0.5m離れた地点にある。 +
 The ball must be at least 0.5 meters away from the robot.
 

--- a/images/double-size-field.svg
+++ b/images/double-size-field.svg
@@ -2,16 +2,16 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="10400"
-   height="7400"
+   width="11440"
+   height="8140"
    id="svg3081"
    version="1.1"
-   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   inkscape:version="1.4.2 (2aeb623e1d, 2025-05-12)"
    inkscape:export-xdpi="11.415141"
    inkscape:export-ydpi="11.415141"
+   sodipodi:docname="double-size-field.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns="http://www.w3.org/2000/svg"
    xmlns:svg="http://www.w3.org/2000/svg"
    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -47,7 +47,7 @@
          id="path4485"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)"
+         transform="scale(-0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -61,7 +61,7 @@
          id="path4482"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(0.6,0.6)"
+         transform="scale(0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -87,7 +87,7 @@
        style="overflow:visible">
       <path
          id="path4470"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(0.2,0,0,0.2,1.2,0)"
          inkscape:connector-curvature="0" />
@@ -98,7 +98,11 @@
        refY="0"
        refX="0"
        id="Arrow2Lend"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 12.01846569 8.8389873"
+       markerWidth="12.01846576"
+       markerHeight="8.83898735"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4479"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
@@ -112,7 +116,11 @@
        refY="0"
        refX="0"
        id="Arrow2Lstart"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 12.01846569 8.8389873"
+       markerWidth="12.01846576"
+       markerHeight="8.83898735"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4476"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
@@ -129,7 +137,7 @@
        style="overflow:visible">
       <path
          id="path4461"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
@@ -143,7 +151,7 @@
        style="overflow:visible">
       <path
          id="path4458"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(0.8,0,0,0.8,10,0)"
          inkscape:connector-curvature="0" />
@@ -468,7 +476,7 @@
          id="path4482-4"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(0.6,0.6)" />
+         transform="scale(0.6)" />
     </marker>
     <marker
        inkscape:stockid="Arrow2Mend"
@@ -482,7 +490,7 @@
          id="path4485-7"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)" />
+         transform="scale(-0.6)" />
     </marker>
     <marker
        inkscape:stockid="Arrow2Mend"
@@ -496,28 +504,8 @@
          id="path4485-5"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)" />
+         transform="scale(-0.6)" />
     </marker>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4271"
-       id="linearGradient4275"
-       x1="383.59586"
-       y1="2591.6891"
-       x2="4438.9408"
-       y2="2591.6891"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3775507,0,0,1.5055393,-532.91326,-6549.5284)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient4277"
-       id="linearGradient4281"
-       x1="383.59586"
-       y1="2591.6891"
-       x2="4438.9408"
-       y2="2591.6891"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(2.3775507,0,0,1.5055393,-532.91326,-6549.5284)" />
     <marker
        inkscape:stockid="Arrow2Lstart"
        orient="auto"
@@ -546,6 +534,118 @@
          transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
          inkscape:connector-curvature="0" />
     </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-2"
+       style="overflow:visible">
+      <path
+         id="path4476-61"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0"
+       style="overflow:visible">
+      <path
+         id="path4479-6"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-4"
+       style="overflow:visible">
+      <path
+         id="path4479-6-9"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-1"
+       style="overflow:visible">
+      <path
+         id="path4479-6-1"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-4-5"
+       style="overflow:visible">
+      <path
+         id="path4479-6-9-9"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-1-5"
+       style="overflow:visible">
+      <path
+         id="path4479-6-1-6"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-1-8"
+       style="overflow:visible">
+      <path
+         id="path4479-6-1-5"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-0-1-5-6"
+       style="overflow:visible">
+      <path
+         id="path4479-6-1-6-1"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -554,17 +654,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.034345258"
-     inkscape:cx="7773.999"
-     inkscape:cy="1048.1796"
+     inkscape:zoom="0.088388348"
+     inkscape:cx="5011.9728"
+     inkscape:cy="3852.3177"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="1952"
-     inkscape:window-height="1123"
-     inkscape:window-x="2710"
-     inkscape:window-y="204"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1854"
+     inkscape:window-height="1131"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
      inkscape:showpageshadow="2"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1" />
@@ -585,48 +685,77 @@
      id="layer1"
      transform="translate(0,6347.6378)">
     <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.10211"
+       id="rect4371-8-4"
+       width="11440.007"
+       height="8140"
+       x="0"
+       y="-6347.6377" />
+    <rect
        style="fill:#00b000;fill-opacity:1;stroke:none;stroke-width:1.10211"
        id="rect4371-8"
        width="10400.006"
        height="7400.0005"
-       x="-0.0016719848"
-       y="-6347.6377" />
+       x="526.75378"
+       y="-5934.064" />
     <rect
-       style="fill:url(#linearGradient4275);fill-opacity:1;fill-rule:evenodd;stroke:url(#linearGradient4281);stroke-width:40.58857346;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:20;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3303"
        width="9639.4111"
        height="6639.4116"
-       x="380.29428"
-       y="-5967.3438" />
-    <rect
-       style="fill:#00b000;fill-opacity:1;stroke:none"
-       id="rect4371"
-       width="9600"
-       height="6600"
-       x="400"
-       y="-5947.6377" />
+       x="907.04968"
+       y="-5619.77" />
     <g
-       id="g4500">
+       id="g4272"
+       transform="translate(526.75543,347.57363)">
+      <rect
+         y="-3167.6377"
+         x="388.17664"
+         height="20"
+         width="301.82339"
+         id="rect7139"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1" />
+      <rect
+         y="-2147.6377"
+         x="388.17664"
+         height="20"
+         width="301.82339"
+         id="rect7139-2"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1" />
+      <rect
+         y="-3147.6377"
+         x="490"
+         height="1000"
+         width="20"
+         id="rect7139-2-6"
+         style="fill:#000000;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="g4500"
+       style="display:inline;stroke-width:20;stroke-dasharray:none"
+       transform="translate(526.75543,347.57363)">
       <g
-         transform="translate(10,0)"
-         id="g4488">
+         transform="translate(10)"
+         id="g4488"
+         style="stroke:#ffffff;stroke-width:20;stroke-dasharray:none;stroke-opacity:1">
         <rect
-           style="fill:#00aa00;fill-opacity:1;stroke:#ffffff;stroke-width:10.48846149;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:20.97692343, 10.48846172;stroke-dashoffset:0;stroke-opacity:1"
+           style="fill:#00aa00;fill-opacity:1;stroke:#ffffff;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
            id="rect3089"
            width="8989.5117"
            height="5989.5117"
            x="689.2442"
            y="-5622.3936"
-           ry="14.464052" />
+           ry="14.464052"
+           rx="14.464052" />
         <rect
-           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:20;stroke-dasharray:none;stroke-opacity:1"
            id="rect4369"
            width="10"
            height="6000"
            x="5179"
            y="-5622.6377" />
         <ellipse
-           style="fill:none;stroke:#ffffff;stroke-width:10;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           style="fill:none;stroke:#ffffff;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            id="path4392"
            cx="5184"
            cy="-2650.3496"
@@ -635,11 +764,11 @@
       </g>
       <rect
          y="-2652.6377"
-         x="692"
+         x="704"
          height="10"
-         width="9000"
+         width="8973"
          id="rect4418"
-         style="fill:#ffffff;fill-opacity:1;stroke:none" />
+         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:20;stroke-dasharray:none;stroke-opacity:1" />
       <rect
          ry="4.8163533"
          y="-3644.8547"
@@ -647,7 +776,8 @@
          height="1994.4343"
          width="994.43427"
          id="rect3089-3"
-         style="fill:none;stroke:#ffffff;stroke-width:10;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:20, 10;stroke-dashoffset:0;stroke-opacity:1" />
+         style="fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         rx="4.8163533" />
       <rect
          ry="4.8163533"
          y="-3644.8552"
@@ -655,89 +785,83 @@
          height="1994.4343"
          width="994.43427"
          id="rect3089-3-2"
-         style="fill:none;stroke:#ffffff;stroke-width:10;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:20, 10;stroke-dashoffset:0;stroke-opacity:1" />
+         style="fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         rx="4.8163533" />
     </g>
     <path
        style="fill:none;stroke:#000000;stroke-width:14.9865;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 3100.8436,-5602.067 V 347.0933"
+       d="M 3627.599,-5254.4934 V 694.66693"
        id="path4452"
        inkscape:connector-curvature="0" />
     <path
        style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 719.3188,-5024.9808 H 9669.1369"
+       d="M 1246.0742,-4237.4072 H 10195.892"
        id="path4452-5"
        inkscape:connector-curvature="0" />
     <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0)"
+       d="M 599.24508,-5101.9985 H 898.73061"
+       id="path4452-5-59"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0-4)"
+       d="M 1535.6745,-5102.5267 H 1236.189"
+       id="path4452-5-59-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0-1)"
+       d="M 987.16147,-4669.7028 H 1196.475"
+       id="path4452-5-59-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0-1-5)"
+       d="M 1465.6447,-4670.231 H 1256.3312"
+       id="path4452-5-59-7-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0-1-8)"
+       d="M 723.00002,-2106.331 H 1016.3226"
+       id="path4452-5-59-7-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:14.9921;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-0-1-5-6)"
+       d="M 1509.2847,-2106.8592 H 1236.0512"
+       id="path4452-5-59-7-9-9"
+       inkscape:connector-curvature="0" />
+    <path
        style="fill:none;stroke:#000000;stroke-width:12.3419;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 4823.4665,-2958.4573 735.6449,621.6402"
+       d="m 5350.2219,-2610.8837 735.6449,621.6402"
        id="path4452-5-3"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 77.711065,1032.4826 0,-7360.2407"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="M 420.4665,1380.0562 V -5980.1845"
        id="path4452-4"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:15.70811558;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 20.860667,-6027.3364 10356.886333,0"
+       style="fill:none;stroke:#000000;stroke-width:15.7081;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="M 547.6161,-6049.7628 H 10904.502"
        id="path4452-5-5"
        inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:10.021;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 9701.3163,7.9911128 h 685.2457"
-       id="path4452-5-7"
-       inkscape:connector-curvature="0"
-       inkscape:export-xdpi="11.415141"
-       inkscape:export-ydpi="11.415141" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:9.59911;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="m 9700.9221,-274.77966 h 287.0052"
-       id="path4452-5-7-6"
-       inkscape:connector-curvature="0" />
-    <g
-       id="g4272"
-       transform="translate(4,0)">
-      <rect
-         y="-3167.6377"
-         x="490"
-         height="20"
-         width="200"
-         id="rect7139"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
-      <rect
-         y="-2147.6377"
-         x="490"
-         height="20"
-         width="200"
-         id="rect7139-2"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
-      <rect
-         y="-3147.6377"
-         x="490"
-         height="1000"
-         width="20"
-         id="rect7139-2-6"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
-    </g>
     <g
        id="g4280"
-       transform="translate(-6,0)">
+       transform="translate(526.75543,347.57363)">
       <rect
          transform="scale(-1,1)"
          y="-3167.6377"
-         x="-9900"
+         x="-10017"
          height="20"
-         width="200"
+         width="317"
          id="rect7139-27"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1" />
       <rect
          transform="scale(-1,1)"
          y="-2147.6377"
-         x="-9900"
+         x="-10019"
          height="20"
-         width="200"
+         width="319"
          id="rect7139-2-64"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1" />
       <rect
          transform="scale(-1,1)"
          y="-3147.6377"
@@ -745,152 +869,190 @@
          height="1000"
          width="20"
          id="rect7139-2-6-5"
-         style="fill:#806600;fill-opacity:1;stroke:none" />
+         style="fill:#000000;fill-opacity:1;stroke:none" />
     </g>
     <path
-       style="fill:none;stroke:#000000;stroke-width:10.09020805;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="m 558.42074,-3134.4128 0,973.317"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 1345.1762,-2786.8392 v 973.317"
        id="path4452-2-9"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:9.75002;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend)"
-       d="M 4209.0809,201.863 V 349.50813"
-       id="path4452-2-5"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:10.2439;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend)"
-       d="M 4209.2789,549.6097 V 386.62839"
-       id="path4452-2-5-2"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Times New Roman;-inkscape-font-specification:Times New Roman"
-       x="3533.3333"
-       y="-6080.9712"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1435.3083"
+       y="-6082.0049"
        id="text8102"><tspan
          sodipodi:role="line"
-         x="3533.3333"
-         y="-6080.9712"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:Verdana"
+         x="1435.3083"
+         y="-6082.0049"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
          id="tspan8106">10400</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Times New Roman;-inkscape-font-specification:Times New Roman"
-       x="4205.9062"
-       y="263.00391"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="4491.9004"
+       y="389.15213"
        id="text8110"
-       transform="matrix(0,-1,1,0,0,0)"><tspan
+       transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan8112"
-         x="4205.9062"
-         y="263.00391"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-family:Verdana;-inkscape-font-specification:Verdana">7400</tspan></text>
+         x="4491.9004"
+         y="389.15213"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">7400</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="3791.6667"
-       y="1583.3333"
-       id="text8114"
-       transform="translate(0,-6347.6378)"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="2278.4224"
+       y="-4280.731"
+       id="text8114"><tspan
          sodipodi:role="line"
-         x="3791.6667"
-         y="1583.3333"
+         x="2278.4224"
+         y="-4280.731"
          id="tspan8118">9000</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="3200"
-       y="2583.3333"
-       id="text8122"
-       transform="translate(0,-6347.6378)"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1560.1232"
+       y="-5029.46"
+       id="text8114-7"><tspan
          sodipodi:role="line"
-         id="tspan8124"
-         x="3200"
-         y="2583.3333">6000</tspan></text>
+         x="1560.1232"
+         y="-5029.46"
+         id="tspan2">300</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="1017.6667"
-       y="-3473.6377"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1485.7118"
+       y="-4597.1641"
+       id="text8114-7-3"><tspan
+         sodipodi:role="line"
+         x="1485.7118"
+         y="-4597.1641"
+         id="tspan3">10</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="3654.7554"
+       y="-4776.7305"
+       id="text8122"><tspan
+         sodipodi:role="line"
+         id="tspan8124"
+         x="3654.7554"
+         y="-4776.7305">6000</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1458.1277"
+       y="-3449.7595"
        id="text8130"><tspan
          sodipodi:role="line"
          id="tspan8132"
-         x="1017.6667"
-         y="-3473.6377"
-         style="font-size:125px">1000</tspan></text>
+         x="1458.1277"
+         y="-3449.7595"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">1000</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="551.18549"
-       y="-2735.9709"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1366.2323"
+       y="-2443.1494"
        id="text8142"><tspan
          sodipodi:role="line"
          id="tspan8144"
-         x="551.18549"
-         y="-2735.9709"
-         style="font-size:125px">1000</tspan></text>
+         x="1366.2323"
+         y="-2443.1494"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">1000</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:125px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="4275"
-       y="6891.6665"
-       id="text8146"
-       transform="translate(0,-6347.6378)"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1511.537"
+       y="-2033.7924"
+       id="text8142-4"><tspan
          sodipodi:role="line"
-         id="tspan8148"
-         x="4275"
-         y="6891.6665"
-         style="font-size:200px">10</tspan></text>
+         x="1511.537"
+         y="-2033.7924"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
+         id="tspan4">160</tspan></text>
     <text
        xml:space="preserve"
-       style="font-size:125px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="9731.2334"
-       y="-322.63779"
-       id="text8150"><tspan
-         sodipodi:role="line"
-         id="tspan8152"
-         x="9731.2334"
-         y="-322.63779">300</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:125px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="10041.434"
-       y="-5.9712963"
-       id="text8154"><tspan
-         sodipodi:role="line"
-         id="tspan8156"
-         x="10041.434"
-         y="-5.9712963">700</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="5170.249"
-       y="-2679.8555"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
+       x="5732.3599"
+       y="-2330.8674"
        id="text8158"><tspan
          sodipodi:role="line"
          id="tspan8160"
-         x="5170.249"
-         y="-2679.8555">1000</tspan></text>
+         x="5732.3599"
+         y="-2330.8674">1000</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:9.97608;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart-4);marker-end:url(#Arrow2Mend-31)"
-       d="m 1581.6168,-3632.2694 v 1969.1216"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 2328.3722,-3273.537 v 1946.0969"
        id="path4452-1"
        inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-size:200px;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none;font-family:Verdana;-inkscape-font-specification:Verdana"
-       x="1210.9218"
-       y="-1839.7581"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:125%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="2364.5486"
+       y="-1523.6647"
        id="text8130-7"><tspan
          sodipodi:role="line"
          id="tspan8132-0"
-         x="1210.9218"
-         y="-1839.7581"
-         style="font-size:125px">2000</tspan></text>
+         x="2364.5486"
+         y="-1523.6647"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">2000</tspan></text>
     <path
-       style="fill:none;stroke:#000000;stroke-width:9.9537;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="M 712.61271,-3403.3854 H 1680.9518"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 1239.3681,-3415.8118 h 968.3391"
        id="path4452-5-3-6-0"
        inkscape:connector-curvature="0" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="M 914.86128,884.55214 V 1011.5521 H 1041.8613 Z"
+       id="path4"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 916.55635,-2945.7921 v 127 h 127.00005 z"
+       id="path4-1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1043.4193,-1780.5697 H 916.41926 v 127 z"
+       id="path4-9"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="M 1042,-5610.6378 H 915 v 127 z"
+       id="path4-9-9"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10537,-5485.6378 v -127 h -127 z"
+       id="path4-9-8"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10538,-1653.6378 v -127 h -127 z"
+       id="path4-9-8-5"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10410,1010.3622 h 127 v -127 z"
+       id="path4-9-8-5-9"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:15;stroke-linecap:square;stroke-miterlimit:0;stroke-dasharray:none;stroke-opacity:1"
+       d="m 10410,-2819.6378 h 127 v -127 z"
+       id="path4-9-8-5-3"
+       sodipodi:nodetypes="cccc" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="4089.3809"
+       y="1702.9667"
+       id="text8102-6"><tspan
+         sodipodi:role="line"
+         x="4089.3809"
+         y="1702.9667"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:200px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
+         id="tspan8106-7">Dimensions for a Division B field</tspan></text>
   </g>
 </svg>

--- a/images/quad-size-field.svg
+++ b/images/quad-size-field.svg
@@ -2,13 +2,14 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   width="13402.885"
-   height="10402.144"
+   width="14743.262"
+   height="11442.223"
    id="svg3081"
    version="1.1"
-   inkscape:version="1.4 (e7c3feb1, 2024-10-09)"
+   inkscape:version="1.4.2 (2aeb623e1d, 2025-05-12)"
    inkscape:export-xdpi="11.415141"
    inkscape:export-ydpi="11.415141"
+   sodipodi:docname="quad-size-field.svg"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -41,12 +42,16 @@
        refY="0"
        refX="0"
        id="Arrow2Mend"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 6.5555267 4.8212658"
+       markerWidth="6.5555267"
+       markerHeight="4.8212657"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4485"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)"
+         transform="scale(-0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -55,12 +60,16 @@
        refY="0"
        refX="0"
        id="Arrow2Mstart"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 6.5555267 4.8212658"
+       markerWidth="6.5555267"
+       markerHeight="4.8212657"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4482"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(0.6,0.6)"
+         transform="scale(0.6)"
          inkscape:connector-curvature="0" />
     </marker>
     <marker
@@ -86,7 +95,7 @@
        style="overflow:visible">
       <path
          id="path4470"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(0.2,0,0,0.2,1.2,0)"
          inkscape:connector-curvature="0" />
@@ -97,7 +106,11 @@
        refY="0"
        refX="0"
        id="Arrow2Lend"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 12.018466 8.8389873"
+       markerWidth="12.018466"
+       markerHeight="8.8389874"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4479"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
@@ -111,7 +124,11 @@
        refY="0"
        refX="0"
        id="Arrow2Lstart"
-       style="overflow:visible">
+       style="overflow:visible"
+       viewBox="0 0 12.018466 8.8389873"
+       markerWidth="12.018466"
+       markerHeight="8.8389874"
+       preserveAspectRatio="xMidYMid">
       <path
          id="path4476"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
@@ -128,7 +145,7 @@
        style="overflow:visible">
       <path
          id="path4461"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(-0.8,0,0,-0.8,-10,0)"
          inkscape:connector-curvature="0" />
@@ -142,7 +159,7 @@
        style="overflow:visible">
       <path
          id="path4458"
-         d="M 0,0 5,-5 -12.5,0 5,5 0,0 z"
+         d="M 0,0 5,-5 -12.5,0 5,5 Z"
          style="fill-rule:evenodd;stroke:#000000;stroke-width:1pt"
          transform="matrix(0.8,0,0,0.8,10,0)"
          inkscape:connector-curvature="0" />
@@ -467,7 +484,7 @@
          id="path4482-4"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(0.6,0.6)" />
+         transform="scale(0.6)" />
     </marker>
     <marker
        inkscape:stockid="Arrow2Mend"
@@ -481,7 +498,7 @@
          id="path4485-7"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)" />
+         transform="scale(-0.6)" />
     </marker>
     <marker
        inkscape:stockid="Arrow2Mend"
@@ -495,7 +512,7 @@
          id="path4485-5"
          style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
          d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
-         transform="scale(-0.6,-0.6)" />
+         transform="scale(-0.6)" />
     </marker>
     <linearGradient
        inkscape:collect="always"
@@ -507,6 +524,278 @@
        y1="2591.6892"
        x2="4438.9409"
        y2="2591.6892" />
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-3"
+       style="overflow:visible">
+      <path
+         id="path4476-67"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53"
+       style="overflow:visible">
+      <path
+         id="path4479-56"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-3-1"
+       style="overflow:visible">
+      <path
+         id="path4476-67-2"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-7"
+       style="overflow:visible">
+      <path
+         id="path4479-56-0"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-7-6"
+       style="overflow:visible">
+      <path
+         id="path4479-56-0-0"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-3-6"
+       style="overflow:visible">
+      <path
+         id="path4476-67-1"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-8"
+       style="overflow:visible">
+      <path
+         id="path4479-56-7"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-7-9"
+       style="overflow:visible">
+      <path
+         id="path4479-56-0-2"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-7-6-0"
+       style="overflow:visible">
+      <path
+         id="path4479-56-0-0-2"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-30"
+       style="overflow:visible">
+      <path
+         id="path4476-7"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-86"
+       style="overflow:visible">
+      <path
+         id="path4479-88"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-3-6-5"
+       style="overflow:visible">
+      <path
+         id="path4476-67-1-0"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-53-8-4"
+       style="overflow:visible">
+      <path
+         id="path4479-56-7-8"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mstart-7"
+       style="overflow:visible"
+       viewBox="0 0 6.5555267 4.8212658"
+       markerWidth="6.5555267"
+       markerHeight="4.8212657"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4482-3"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-6"
+       style="overflow:visible"
+       viewBox="0 0 6.5555267 4.8212658"
+       markerWidth="6.5555267"
+       markerHeight="4.8212657"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4485-56"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lstart"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lstart-4"
+       style="overflow:visible"
+       viewBox="0 0 12.018466 8.8389873"
+       markerWidth="12.018466"
+       markerHeight="8.8389874"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4476-8"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(1.1,0,0,1.1,1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-12"
+       style="overflow:visible"
+       viewBox="0 0 12.018466 8.8389873"
+       markerWidth="12.018466"
+       markerHeight="8.8389874"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4479-93"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Lend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Lend-12-8"
+       style="overflow:visible"
+       viewBox="0 0 12.018466 8.8389873"
+       markerWidth="12.018466"
+       markerHeight="8.8389874"
+       preserveAspectRatio="xMidYMid">
+      <path
+         id="path4479-93-8"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="matrix(-1.1,0,0,-1.1,-1.1,0)"
+         inkscape:connector-curvature="0" />
+    </marker>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -515,17 +804,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="0.049603916"
-     inkscape:cx="22538.543"
-     inkscape:cy="7297.8109"
+     inkscape:zoom="0.059730322"
+     inkscape:cx="7299.4751"
+     inkscape:cy="6186.1378"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="false"
-     inkscape:window-width="3840"
-     inkscape:window-height="1547"
-     inkscape:window-x="1728"
-     inkscape:window-y="25"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1854"
+     inkscape:window-height="1131"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
      showguides="false"
      inkscape:guide-bbox="true"
      fit-margin-top="0"
@@ -544,7 +833,6 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -555,296 +843,247 @@
      transform="translate(-2.1154376,9352.6377)"
      style="display:inline">
     <rect
-       style="fill:#00c100;fill-opacity:1;stroke:none;stroke-width:1.00021"
+       style="opacity:1;fill:#ffffff;stroke:#00ffff;stroke-width:1;stroke-dasharray:35.3894, 17.6946;stroke-dashoffset:0"
+       id="rect1"
+       width="14742.262"
+       height="11441.223"
+       x="2.6157188"
+       y="-9352.1377" />
+    <rect
+       style="fill:#00b000;fill-opacity:1;stroke:none;stroke-width:1.00021"
        id="rect4367"
        width="13402.965"
        height="10402.021"
-       x="2.0998788"
-       y="-9352.6748" />
+       x="672.26416"
+       y="-8832.5371" />
     <rect
-       style="display:inline;fill:#00b000;fill-opacity:1;stroke:none;stroke-width:17.98813057;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.99549549"
+       style="display:inline;fill:#00b000;fill-opacity:1;stroke:none;stroke-width:17.9881;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.995495"
        id="rect4371"
-       width="12583.396"
+       width="13183.396"
        height="9599.9941"
-       x="429.41302"
-       y="-8952.6348" />
-    <rect
-       style="fill:#00aa00;fill-opacity:1;stroke:#ffffff;stroke-width:14.86200047;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:29.724, 14.862;stroke-dashoffset:0;stroke-opacity:1"
-       id="rect3089"
-       width="12005.138"
-       height="9005.1387"
-       x="712.43097"
-       y="-8665.6631"
-       ry="21.746479"
-       inkscape:export-xdpi="11.415141"
-       inkscape:export-ydpi="11.415141" />
-    <rect
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       id="rect4369"
-       width="10"
-       height="9000"
-       x="6695"
-       y="-8647.6377" />
+       x="799.57776"
+       y="-8432.4971" />
     <ellipse
-       style="fill:none;stroke:#ffffff;stroke-width:9.94605446;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       style="fill:none;stroke:#ffffff;stroke-width:9.94605;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="path4392"
-       cx="6696"
-       cy="-4147.6377"
+       cx="7366.1641"
+       cy="-3627.5"
        rx="495.02695"
        ry="495.02698" />
-    <rect
-       style="fill:#ffffff;fill-opacity:1;stroke:none"
-       id="rect4418"
-       width="12020"
-       height="10"
-       x="705"
-       y="-4152.6377" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:19.9862;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 3100.8436,-8639.4463 V 313.66202"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="M 3771.0078,-8083.9716 V 863.64451"
        id="path4452"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:19.9897;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 739.10577,-7970.9808 H 12691.502"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="M 1401.283,-6930.8433 H 13361.417"
        id="path4452-5"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:12.3536;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 6333.7665,-4461.0516 728.6031,622.205"
-       id="path4452-5-3"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:17.5961;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 97.711065,1026.129 V -9329.3204"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 533.87532,1546.2668 c 0,-3451.8165 0,-6903.6329 0,-10355.4494"
        id="path4452-4"
        inkscape:connector-curvature="0" />
     <path
-       style="fill:none;stroke:#000000;stroke-width:17.6946;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="M 25.621619,-9029.3364 H 13381.499"
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 695.78592,-8951.1986 c 4451.95908,0 8903.91828,0 13355.87708,0"
        id="path4452-5-5"
        inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:9.96352;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
-       d="m 12729.819,7.9911128 h 661.699"
-       id="path4452-5-7"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:10.6512;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="m 12730.727,-355.25278 h 267.165"
-       id="path4452-5-7-6"
-       inkscape:connector-curvature="0" />
     <g
-       id="g4272"
-       transform="matrix(1,0,0,1.7884616,15,572.56051)"
-       style="opacity:0.58499995">
+       id="g4272-9"
+       transform="matrix(-1,0,0,-1.7692308,14080.717,-8311.7819)"
+       style="display:inline;opacity:1;stroke-width:0.751809;stroke-dasharray:none">
       <rect
          y="-3167.6377"
          x="490"
-         height="20"
+         height="11.304348"
          width="200"
-         id="rect7139"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
+         id="rect7139-20"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
       <rect
-         y="-2147.6377"
+         y="-2138.9419"
          x="490"
-         height="20"
+         height="11.304348"
          width="200"
-         id="rect7139-2"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
+         id="rect7139-2-68"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
       <rect
-         y="-3147.6377"
+         y="-3156.3333"
          x="490"
-         height="1000"
+         height="1017.3913"
          width="20"
-         id="rect7139-2-6"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
+         id="rect7139-2-6-9"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
     </g>
-    <g
-       id="g4280"
-       transform="matrix(1,0,0,1.7884616,3025,572.56041)">
-      <rect
-         transform="scale(-1,1)"
-         y="-3167.6377"
-         x="-9900"
-         height="20"
-         width="200"
-         id="rect7139-27"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
-      <rect
-         transform="scale(-1,1)"
-         y="-2147.6377"
-         x="-9900"
-         height="20"
-         width="200"
-         id="rect7139-2-64"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
-      <rect
-         transform="scale(-1,1)"
-         y="-3147.6377"
-         x="-9900"
-         height="1000"
-         width="20"
-         id="rect7139-2-6-5"
-         style="fill:#0000ff;fill-opacity:1;stroke:none" />
-    </g>
-    <path
-       style="fill:none;stroke:#000000;stroke-width:13.37597656;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="m 554.42074,-5036.206 v 1748.1199"
-       id="path4452-2-9"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend)"
-       d="M 4209.0809,163.863 V 319.17624"
-       id="path4452-2-5"
-       inkscape:connector-curvature="0" />
-    <path
-       style="fill:none;stroke:#000000;stroke-width:10;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:none;marker-end:url(#Arrow2Mend)"
-       d="M 4209.2789,515.6097 V 360.2965"
-       id="path4452-2-5-2"
-       inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="3714.3977"
-       y="-9102.3477"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="2108.0242"
+       y="-8978.21"
        id="text8102"><tspan
          sodipodi:role="line"
-         x="3714.3977"
-         y="-9102.3477"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:250px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana"
+         x="2108.0242"
+         y="-8978.21"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
          id="tspan8106">13400</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-weight:normal;line-height:0%;font-family:'Times New Roman';-inkscape-font-specification:'Times New Roman';letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="6130.9062"
-       y="316.50391"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="5227.9917"
+       y="1932.2382"
+       id="text8102-6"><tspan
+         sodipodi:role="line"
+         x="5227.9917"
+         y="1932.2382"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
+         id="tspan8106-7">Dimensions for a Division A field</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="6659.1973"
+       y="500.63464"
        id="text8110"
        transform="rotate(-90)"><tspan
          sodipodi:role="line"
          id="tspan8112"
-         x="6130.9062"
-         y="316.50391"
-         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:250px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:Verdana">10400</tspan></text>
+         x="6659.1973"
+         y="500.63464"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">10400</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="4385.1562"
-       y="-7751.8691"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="2288.9751"
+       y="-6964.1294"
        id="text8114"><tspan
          sodipodi:role="line"
-         x="4385.1562"
-         y="-7751.8691"
+         x="2288.9751"
+         y="-6964.1294"
          id="tspan8118"
-         style="font-size:250px;line-height:1.25">12000</tspan></text>
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">12000</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="3178"
-       y="-3764.3044"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="3822.2957"
+       y="-7460.7524"
        id="text8122"><tspan
          sodipodi:role="line"
          id="tspan8124"
-         x="3178"
-         y="-3764.3044"
-         style="font-size:250px;line-height:1.25">9000</tspan></text>
+         x="3822.2957"
+         y="-7460.7524"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">9000</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="1249.4501"
-       y="-3243.1121"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="2050.8611"
+       y="-2049.687"
        id="text8126"><tspan
          sodipodi:role="line"
          id="tspan8128"
-         x="1249.4501"
-         y="-3243.1121"
-         style="font-size:200px;line-height:1.25">3600</tspan></text>
+         x="2050.8611"
+         y="-2049.687"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">3600</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="1107.4729"
-       y="-5461.084"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="1839.7214"
+       y="-3197.0569"
+       id="text8126-6"><tspan
+         sodipodi:role="line"
+         id="tspan8128-3"
+         x="1839.7214"
+         y="-3197.0569"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">160</tspan></text>
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1606.5193"
+       y="-4922.7227"
        id="text8130"><tspan
          sodipodi:role="line"
          id="tspan8132"
-         x="1107.4729"
-         y="-5461.084"
-         style="font-size:200px;line-height:1.25">1800</tspan></text>
+         x="1606.5193"
+         y="-4922.7227"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">1800</tspan></text>
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Lstart-3-6);marker-end:url(#Arrow2Lend-53-8)"
+       d="m 832.32652,-7765.9912 c 174.25208,0 348.50618,0 522.75838,0"
+       id="path4452-4-9-7"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
+       d="m 2481.7417,-8146.2143 c 0,-92.9182 0,-185.8373 0,-278.7555"
+       id="path4452-4-9-7-1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#Arrow2Lend-53-7-9)"
+       d="m 1066.4766,-7348.1528 c 96.498,0 192.998,0 289.496,0"
+       id="path4452-4-9-3-5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker-end:url(#Arrow2Lend-53-7-6-0)"
+       d="m 1697.6542,-7348.6813 c -96.498,0 -192.998,0 -289.496,0"
+       id="path4452-4-9-3-2-9"
+       inkscape:connector-curvature="0" />
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="4243"
-       y="540.02869"
-       id="text8146"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="1394.495"
+       y="-7668.9209"
+       id="text8150-2"><tspan
          sodipodi:role="line"
-         id="tspan8148"
-         x="4243"
-         y="540.02869"
-         style="font-size:250px;line-height:1.25">10</tspan></text>
+         id="tspan8152-2"
+         x="1394.495"
+         y="-7668.9209"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">600</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="12578.68"
-       y="-413.17004"
-       id="text8150"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="2547.8379"
+       y="-8188.5215"
+       id="text8150-2-2"><tspan
          sodipodi:role="line"
-         id="tspan8152"
-         x="12578.68"
-         y="-413.17004"
-         style="font-size:200px;line-height:1.25">300</tspan></text>
+         id="tspan8152-2-7"
+         x="2547.8379"
+         y="-8188.5215"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">300</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="13006.568"
-       y="-33.097767"
-       id="text8154"><tspan
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;display:inline;fill:#000000;fill-opacity:1;stroke:none"
+       x="1707.6851"
+       y="-7251.3467"
+       id="text8154-8"><tspan
          sodipodi:role="line"
-         id="tspan8156"
-         x="13006.568"
-         y="-33.097767"
-         style="font-size:200px;line-height:1.25">700</tspan></text>
+         x="1707.6851"
+         y="-7251.3467"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
+         id="tspan1-9">10</tspan></text>
     <text
        xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
-       x="6598.6465"
-       y="-4249.0815"
-       id="text8158"><tspan
-         sodipodi:role="line"
-         id="tspan3646"
-         x="6598.6465"
-         y="-4249.0815"
-         style="font-size:200px;line-height:3.45">1000</tspan></text>
-    <text
-       xml:space="preserve"
-       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Verdana;-inkscape-font-specification:Verdana;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
-       x="582.64917"
-       y="-4384.8379"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:none"
+       x="1495.9142"
+       y="-4068.5015"
        id="text8142"><tspan
          sodipodi:role="line"
-         x="582.64917"
-         y="-4384.8379"
-         style="font-size:200px;line-height:1.25"
+         x="1495.9142"
+         y="-4068.5015"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:1.25;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal"
          id="tspan142">1800</tspan></text>
     <path
-       style="display:inline;fill:none;stroke:#ffffff;stroke-width:21.92668915;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 13006.254,-2346.8018 h -2126.071 v -3636.2889 l 2123.97,0.096"
-       id="path9351"
-       inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccc" />
-    <path
-       style="display:inline;fill:none;stroke:#ffffff;stroke-width:21.56504631;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-       d="m 436.64109,-5981.184 2112.26321,-0.032 v 3633.3162 L 437.02913,-2348.41"
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 1376.7564,-5442.4678 1814.9999,-0.032 v 3629.9985 l -1814.6665,-0.5097"
        id="path9351-1"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="cccc" />
     <path
-       style="display:inline;fill:none;stroke:#000000;stroke-width:12.2126;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="m 1813.878,-5965.5077 v 3602.3714"
-       id="path4452-2"
-       inkscape:connector-curvature="0" />
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 13390.717,-1812.532 -1815,0.032 v -3629.9985 l 1814.666,0.5097"
+       id="path9351-1-6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
     <path
-       style="display:inline;fill:none;stroke:#000000;stroke-width:12.1901;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Mstart);marker-end:url(#Arrow2Mend)"
-       d="M 727.58445,-5389.3829 H 2533.3638"
+       style="display:inline;fill:none;stroke:#000000;stroke-width:12.1901;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="M 1397.4544,-4869.2451 H 3170.3105"
        id="path4452-5-3-6-0"
        inkscape:connector-curvature="0" />
     <flowRoot
@@ -861,11 +1100,144 @@
            y="1802.1436" /></flowRegion><flowPara
          id="flowPara152" /></flowRoot>
     <path
-       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:14.7;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:3.6;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.977477;image-rendering:auto"
+       style="display:inline;opacity:1;fill:none;fill-opacity:1;stroke:#000000;stroke-width:15;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:3.6;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:0.977477;image-rendering:auto"
        clip-path="none"
-       d="m 436.79989,-4149.8596 c 0.24238,-552.7741 1.12054,-2402.7292 1.12054,-2402.7292 l -1.17391,-1199.9993 V -8952.5874 H 3582.5958 6728.445 9874.2943 13020.144 l -0.101,4788.7401 m -0.06,14.1539 0.162,4797.10022 -12583.39748,3e-5 c 0,0 -0.26003,-3502.01205 0.0501,-4796.46235"
+       d="m 806.97152,-3629.7221 c 0.2539,-552.7741 1.174,-2402.7292 1.174,-2402.7292 l -1.2299,-1199.9993 v -1199.9993 h 3295.84808 3295.848 3295.8483 3295.848 l -0.106,4788.7401 m -0.06,14.1539 0.17,4797.1002 H 806.91962 c 0,0 -0.2724,-3502.012 0.053,-4796.4623"
        id="rect9028"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       style="fill:none;stroke:#ffffff;stroke-width:20.0001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="M 7380.717,-8116.1502 V 847.57251"
+       id="path3" />
+    <path
+       style="display:inline;fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="M 13367.359,-3634.2888 H 1394.0744"
+       id="path3-9" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:12.3536;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 7003.9308,-3940.9138 728.6031,622.205"
+       id="path4452-5-3"
+       inkscape:connector-curvature="0" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:0%;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       x="7390.6895"
+       y="-3670.2617"
+       id="text8158"><tspan
+         sodipodi:role="line"
+         id="tspan3646"
+         x="7390.6895"
+         y="-3670.2617"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:266.667px;line-height:3.45;font-family:Verdana;-inkscape-font-specification:'Verdana, Normal';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal">1000</tspan></text>
+    <path
+       style="fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 1486.6983,-4507.4993 v 1759.9988"
+       id="path4452-2-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-12)"
+       d="M 924.05072,-3288.9639 H 1173.0361"
+       id="path4452-2-9-0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:12.2126;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-start:url(#Arrow2Lstart);marker-end:url(#Arrow2Lend)"
+       d="m 2784.0422,-5421.441 v 3586.3142"
+       id="path4452-2"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="M 1165.9088,-4537.5 H 820.07672"
+       id="path4" />
+    <path
+       style="fill:none;stroke:#000000;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="M 1169.0017,-2717.4997 H 821.61722"
+       id="path5" />
+    <path
+       style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 813.90542,1033.8986 126.9999,127 h -126.9999 z"
+       id="path6"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13856.6,1160.816 127,-127 v 127 z"
+       id="path6-2"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13983.389,-8299.8007 -127,-127 h 127 z"
+       id="path6-2-1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 941.24622,-8424.979 -127,127 v -127 z"
+       id="path6-2-6"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 813.31272,-4672.5 127,127 h -127 z"
+       id="path6-2-5"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 941.01002,-2708.1047 -127,127 v -127 z"
+       id="path6-2-5-4"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13601.329,-2717.4904 h 375.623"
+       id="path4-0" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13600.995,-4537.3331 h 375.751"
+       id="path5-9" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13984.406,-2581.8022 -127,-127 h 127 z"
+       id="path6-2-5-1"
+       sodipodi:nodetypes="cccc" />
+    <path
+       style="display:inline;fill:#000000;fill-opacity:1;stroke:none;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 13856.708,-4546.1975 127,-127 v 127 z"
+       id="path6-2-5-4-7"
+       sodipodi:nodetypes="cccc" />
+    <g
+       id="g4272"
+       transform="matrix(1,0,0,1.7692308,685.16432,1056.7821)"
+       style="opacity:1;stroke-width:0.751809;stroke-dasharray:none">
+      <rect
+         y="-3167.6377"
+         x="490"
+         height="11.304348"
+         width="200"
+         id="rect7139"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
+      <rect
+         y="-2138.9419"
+         x="490"
+         height="11.304348"
+         width="200"
+         id="rect7139-2"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
+      <rect
+         y="-3156.3333"
+         x="490"
+         height="1017.3913"
+         width="20"
+         id="rect7139-2-6"
+         style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.751809;stroke-dasharray:none" />
+    </g>
+    <rect
+       style="fill:none;stroke:#ffffff;stroke-width:20;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:0;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       id="rect2"
+       width="12010"
+       height="9010"
+       x="1375.7169"
+       y="-8116.1504" />
+    <path
+       style="display:inline;fill:none;stroke:#000000;stroke-width:15;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker-end:url(#Arrow2Lend-12-8)"
+       d="M 1861.8933,-3289.7346 H 1384.5584"
+       id="path4452-2-9-0-0"
+       inkscape:connector-curvature="0" />
   </g>
 </svg>


### PR DESCRIPTION
[本家Pull Request 103](https://github.com/robocup-ssl/ssl-rules/pull/103)の作業です。  

「ロボットがそのエリアにいる場合は審判に許可を取ることなくロボットを交代させてもよい」というエリアが、Div Aについては自陣側ゴールラインの後ろ側に増えます。  
またゴール後ろ側にロボットやボールが入り込まないよう、各ゴールの両サイドの壁が当該ゴール最寄りの外周壁まで伸びていることが明記されます。  
これに合わせてフィールド図が更新されます。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review

TODO: `center substitution area` および `goal substitution area` の訳の再検討もしくは原文表記への修正