### PR TITLE
Rules2026/104  「Emergency Stop」を「Forced Timeout」に改称

### DIFF
--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -170,7 +170,7 @@ during <<停止/Stop, Stop>>
 | (次の停止時に)<<Halt>>、次いで<<停止/Stop, 停止>> +
 <<Halt>> (after next stoppage), then <<停止/Stop, Stop>> | no | remote control
 || <<チャレンジフラッグ/Challenge Flags, CHALLENGE_FLAG>> | 常時/always | - | no | remote control
-|| <<非常停止/Emergency stop, EMERGENCY_STOP>> | 常時/always | <<Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
+|| <<非常停止/Forced Timeout, EMERGENCY_STOP>> | 常時/always | <<Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
 
 6+| *手動/Manual*
 || <<得点/Scoring Goals, GOAL>> | - | <<停止/Stop>> -> <<キックオフ/Kick-Off>> | no | human referee

--- a/chapters/appendix.adoc
+++ b/chapters/appendix.adoc
@@ -170,7 +170,7 @@ during <<停止/Stop, Stop>>
 | (次の停止時に)<<Halt>>、次いで<<停止/Stop, 停止>> +
 <<Halt>> (after next stoppage), then <<停止/Stop, Stop>> | no | remote control
 || <<チャレンジフラッグ/Challenge Flags, CHALLENGE_FLAG>> | 常時/always | - | no | remote control
-|| <<非常停止/Forced Timeout, EMERGENCY_STOP>> | 常時/always | <<Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
+|| <<強制タイムアウト/Forced Timeout, EMERGENCY_STOP>> | 常時/always | <<Halt>> -> <<タイムアウト/Timeouts, Timeout>> + <<イエローカード/Yellow Card>>>> | no | remote control
 
 6+| *手動/Manual*
 || <<得点/Scoring Goals, GOAL>> | - | <<停止/Stop>> -> <<キックオフ/Kick-Off>> | no | human referee

--- a/chapters/forcedtimeout.adoc
+++ b/chapters/forcedtimeout.adoc
@@ -9,7 +9,7 @@ It will receive a yellow card for this and must take a timeout immediately.
 If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
 NOTE: このルールは極端な - 例えばソフトウェアがクラッシュした、ロボットが自分自身にダメージを与えている、といった - 状況でのみ使用されることを想定する。ロボットが参加者を危険にさらすほど故障した場合、審判は直ちに試合をHaltさせ、当該チームに「<<危険操作/Unsafe Operations, 危険操作>>」としてペナルティを科すことができる。 +
-This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediatley invoke Halt, and may choose to penalize the team for <<危険操作/Unsafe Operations, unsafe operations>>.
+This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediately invoke Halt, and may choose to penalize the team for <<危険操作/Unsafe Operations, unsafe operations>>.
 
 このルールで試合が停止された場合、以下の3つの可能性が考えられる: +
 When the game is stopped due to this rule, there are three possibilities that may have happened:

--- a/chapters/forcedtimeout.adoc
+++ b/chapters/forcedtimeout.adoc
@@ -1,15 +1,15 @@
-== 非常停止/Emergency stop
+== 非常停止/Forced Timeout
 
 .定義/Definition
 チームは現在の状況に関係なく、10秒の猶予時間後もしくは次のストップのいずれか早い時点でゲームを停止するよう要求できる。
 これはイエローカードとなり、直ちにタイムアウトの取得となる。
 非常停止を要求したチームにタイムアウトが残されていない場合でもフィールド上からロボットを取り除くことはできるが、残りのタイムアウト時間を使用することはできない。 +
-A team can ask to stop the game immediately after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
+A team can ask to stop the game after a grace period of 10 seconds or at the next stoppage, whichever happens first regardless of the current situation.
 It will receive a yellow card for this and must take a timeout immediately.
 If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
 NOTE: このルールは極端な - 例えばソフトウェアがクラッシュした、ロボットが自分自身にダメージを与えている、といった - 状況でのみ使用されることを想定する。 +
-This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly.
+This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediatley invoke Halt, and may choose to penalize the team for <<Unsafe Operations, unsafe operations>>.
 
 このルールで試合が停止された場合、以下の3つの可能性が考えられる: +
 When the game is stopped due to this rule, there are three possibilities that may have happened:
@@ -31,7 +31,7 @@ For *3*, the game is continued like after a regular timeout.
 
 .用途/Usage
 非常停止の意図は<<コミュニケーションフラッグ/Communication Flags, コミュニケーションフラッグ>>を使用して伝えらえる。 +
-An emergency stop intent can be made using <<コミュニケーションフラッグ/Communication Flags, communication flags>>.
+A forced timeout intent can be made using <<コミュニケーションフラッグ/Communication Flags, communication flags>>.
 
 NOTE: 主審は、有望なプレイが行われていない場合は猶予時間より早く試合を停止することができる。 +
 The referee may stop the game earlier if there is no promising play in action.

--- a/chapters/forcedtimeout.adoc
+++ b/chapters/forcedtimeout.adoc
@@ -1,4 +1,4 @@
-== 非常停止/Forced Timeout
+== 強制タイムアウト/Forced Timeout
 
 .定義/Definition
 チームは現在の状況に関係なく、10秒の猶予時間後もしくは次のストップのいずれか早い時点でゲームを停止するよう要求できる。
@@ -8,8 +8,8 @@ A team can ask to stop the game after a grace period of 10 seconds or at the nex
 It will receive a yellow card for this and must take a timeout immediately.
 If the team is out of timeouts, it is still allowed to remove robots from the field, but can not use any remaining timeout time.
 
-NOTE: このルールは極端な - 例えばソフトウェアがクラッシュした、ロボットが自分自身にダメージを与えている、といった - 状況でのみ使用されることを想定する。 +
-This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediatley invoke Halt, and may choose to penalize the team for <<Unsafe Operations, unsafe operations>>.
+NOTE: このルールは極端な - 例えばソフトウェアがクラッシュした、ロボットが自分自身にダメージを与えている、といった - 状況でのみ使用されることを想定する。ロボットが参加者を危険にさらすほど故障した場合、審判は直ちに試合をHaltさせ、当該チームに「<<危険操作/Unsafe Operations, 危険操作>>」としてペナルティを科すことができる。 +
+This rule is supposed to be used in extreme situations only, e.g. a software crash or when robots are damaging themselves significantly. If robots are failing to the extent they are endangering the participants, the referee should immediatley invoke Halt, and may choose to penalize the team for <<危険操作/Unsafe Operations, unsafe operations>>.
 
 このルールで試合が停止された場合、以下の3つの可能性が考えられる: +
 When the game is stopped due to this rule, there are three possibilities that may have happened:
@@ -30,7 +30,7 @@ For *1* and *2*, the game is continued with a <<フリーキック/Free Kick, fr
 For *3*, the game is continued like after a regular timeout.
 
 .用途/Usage
-非常停止の意図は<<コミュニケーションフラッグ/Communication Flags, コミュニケーションフラッグ>>を使用して伝えらえる。 +
+強制タイムアウトの意図は<<コミュニケーションフラッグ/Communication Flags, コミュニケーションフラッグ>>を使用して伝えらえる。 +
 A forced timeout intent can be made using <<コミュニケーションフラッグ/Communication Flags, communication flags>>.
 
 NOTE: 主審は、有望なプレイが行われていない場合は猶予時間より早く試合を停止することができる。 +

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -49,6 +49,9 @@ It is not allowed to damage or modify robots of other teams.
 フィールドやボールを損傷させたり変形させたりしてはならない。 +
 It is not allowed to damage or modify the field or the ball.
 
+==== Unsafe Operations
+It is not allowed to have robot failures that endanger the participants or spectators. Examples of unsafe operations include, but are not limited to: high power or high velocity uncontrolled robot operation, electronics fire, high voltage or visible arc discharge.
+
 ==== 手順の軽視/Disrespect Procedures
 次に示すような行為を繰り返してはならない。 +
 Not following defined procedures repetitively, like for example:

--- a/chapters/offenses.adoc
+++ b/chapters/offenses.adoc
@@ -49,7 +49,8 @@ It is not allowed to damage or modify robots of other teams.
 フィールドやボールを損傷させたり変形させたりしてはならない。 +
 It is not allowed to damage or modify the field or the ball.
 
-==== Unsafe Operations
+==== 危険操作/Unsafe Operations
+参加者や観客を危険にさらすようなロボットの故障は許されない。危険操作にはたとえば次のようなものを含むがこれに限らない: 高出力もしくは高速での制御不能なロボット動作、電子機器の発火、高電圧または目に見えるようなアーク放電。 +
 It is not allowed to have robot failures that endanger the participants or spectators. Examples of unsafe operations include, but are not limited to: high power or high velocity uncontrolled robot operation, electronics fire, high voltage or visible arc discharge.
 
 ==== 手順の軽視/Disrespect Procedures

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -169,7 +169,8 @@ It is a physical device that allows entering the following commands:
 
 - タイムアウトを要求する +
 Request a timeout
-- Request a forced timeout
+- 強制タイムアウトを要求する +
+Request a forced timeout
 - ロボットの交代を要求する +
 Request robot substitution
 - キーパーのIDを変更する +
@@ -196,9 +197,9 @@ The official implementation for the league can be found on GitHub: https://githu
 === コミュニケーションフラッグ/Communication Flags
 
 コミュニケーションフラッグは、試合中の<<主審/Referee, 主審>>に対するジェスチャーや野次を回避するために用いられる。
-これらのフラッグは<<タイムアウト/Timeouts, タイムアウト>>や<<非常停止/Forced Timeout, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
+これらのフラッグは<<タイムアウト/Timeouts, タイムアウト>>や<<強制タイムアウト/Forced Timeout, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
 The communication flags are used to avoid gesturing and yelling with the <<主審/Referee, referee>> during a match.
-These flags are responsible for communicating various intents, such as: <<タイムアウト/Timeouts, timeouts>>, <<非常停止/Forced Timeout, forced timeout>>, <<ロボットの交代/Robot Substitution, manual robot substitution>> and <<チャレンジフラッグ/Challenge Flags, challenges>>.
+These flags are responsible for communicating various intents, such as: <<タイムアウト/Timeouts, timeouts>>, <<強制タイムアウト/Forced Timeout, forced timeout>>, <<ロボットの交代/Robot Substitution, manual robot substitution>> and <<チャレンジフラッグ/Challenge Flags, challenges>>.
 
 <<主審/Referee, 主審>>もしくは<<Game Controller Operator, game controller operator>>がコミュニケーションフラッグを確認する必要がある。
 ジェスチャーや野次は<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなされ、一度の警告ののちに<<レッドカード/Red Card, レッドカード>>となる。 +

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -167,16 +167,15 @@ Individual game events can be disabled completely or in some automatic referee i
 A remote control for each team can optionally be provided by the tournament organizers.
 It is a physical device that allows entering the following commands:
 
-- チャレンジフラッグを揚げる +
-Raise a challenge flag
 - タイムアウトを要求する +
 Request a timeout
+- Request a forced timeout
 - ロボットの交代を要求する +
 Request robot substitution
-- 非常停止を要求する +
-Request emergency stop
 - キーパーのIDを変更する +
 Change the keeper id
+- チャレンジフラッグを揚げる +
+Raise a challenge flag
 
 また、これは次のようなフィードバック情報を提供するかもしれない: +
 It may also provide feedback information, like:
@@ -197,9 +196,9 @@ The official implementation for the league can be found on GitHub: https://githu
 === コミュニケーションフラッグ/Communication Flags
 
 コミュニケーションフラッグは、試合中の<<主審/Referee, 主審>>に対するジェスチャーや野次を回避するために用いられる。
-これらのフラッグは<<タイムアウト/Timeouts, タイムアウト>>や<<非常停止/Emergency stop, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
+これらのフラッグは<<タイムアウト/Timeouts, タイムアウト>>や<<非常停止/Forced Timeout, 非常停止>>、<<ロボットの交代/Robot Substitution, 手動でのロボットの交代>>、<<チャレンジフラッグ/Challenge Flags, チャレンジ>>など、さまざまな場面で用いられる。 +
 The communication flags are used to avoid gesturing and yelling with the <<主審/Referee, referee>> during a match.
-These flags are responsible for communicating various intents, such as: <<タイムアウト/Timeouts, timeouts>>, <<非常停止/Emergency stop, emergency stops>>, <<ロボットの交代/Robot Substitution, manual robot substitution>> and <<チャレンジフラッグ/Challenge Flags, challenges>>.
+These flags are responsible for communicating various intents, such as: <<タイムアウト/Timeouts, timeouts>>, <<非常停止/Forced Timeout, forced timeout>>, <<ロボットの交代/Robot Substitution, manual robot substitution>> and <<チャレンジフラッグ/Challenge Flags, challenges>>.
 
 <<主審/Referee, 主審>>もしくは<<Game Controller Operator, game controller operator>>がコミュニケーションフラッグを確認する必要がある。
 ジェスチャーや野次は<<非スポーツマン行為/Unsporting Behavior, 非スポーツマン行為>>とみなされ、一度の警告ののちに<<レッドカード/Red Card, レッドカード>>となる。 +

--- a/sslrules.adoc
+++ b/sslrules.adoc
@@ -41,7 +41,7 @@ include::chapters/substitution.adoc[]
 
 include::chapters/shootout.adoc[]
 
-include::chapters/emergencystop.adoc[]
+include::chapters/forcedtimeout.adoc[]
 
 include::chapters/challengeflag.adoc[]
 


### PR DESCRIPTION
[本家Pull Request 104](https://github.com/robocup-ssl/ssl-rules/pull/104)の作業です。  

現状の「Emergency stop」には猶予時間が含まれるためこれを「Forced Timeout」に改称し、代わりにロボットの暴走や八課といった非常事態を罰するための反則として「Unsafe Operations」を追加します。

加えて、当該プルリクエストで生じた誤字を修正するプルリクエスト robocup-ssl/ssl-rules#107 の内容も取り込みます。和訳には影響しません。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review