### PR TITLE
Rules2026/105 共有Visionシステム関連の文面更新

### DIFF
--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -125,14 +125,21 @@ The shared software used in the Small Size League is maintained by the <<技術�
 
 ==== Vision
 それぞれのフィールドには共有のビジョンサーバーと共有のカメラが設置されている。この共有ビジョン機器はコミュニティーにメンテナンスされているSSL-Vision ソフトウェア(https://github.com/RoboCup-SSL/ssl-vision) が使用される。SSL-Visionはイーサーネット経由で競技会の前に共有ビジョンシステム開発者によって通達されたパケット形式で位置情報を各チームに提供する。各チームはシステムが共有ビジョンシステムと互換性があり、システムが共有ビジョンシステムによって提供される実際のセンサーのデータの(ノイズ、レイテンシ、誤検出、欠落を含む)典型的な特性を処理できることを確認する必要がある。ロボット最上部にあるビジョンパターンはSSL-Visionの仕様に準拠している必要があり、SSL-Visionのマニュアルで指定されている標準のカラーペーパーでなければならない。 +
-Each field is provided with a shared central vision server and a set of shared cameras. This shared vision equipment uses the community-maintained SSL-Vision software (https://github.com/RoboCup-SSL/ssl-vision) to provide localization data to teams via Ethernet in a packet format that is to be announced by the shared vision system developers before the competition. Teams need to ensure that their systems are compatible with the shared vision system output and that their systems are able to handle the typical properties of real-world sensory data as provided by the shared vision system (including noise, latency, or occasional failed detections and misclassifications). The vision patterns on the top of the robots must adhere to the specifications of SSL-Vision, and must be of the standard color paper as specified in the SSL-Vision documentation.
+Each field is provided with a shared vision system and a set of shared cameras. This shared vision equipment provides localization data to teams via Ethernet in a packet format that is to be announced by the shared vision system developers before the competition. If multiple vision systems are approved for a competitive event, the organizers will describe in advance which one(s) will be available for use.
+
+There are currently two software implementations that are approved for use at a competitive event.
+
+- SSL-Vision (https://github.com/RoboCup-SSL/ssl-vision)
+- Vision Processor (https://github.com/TIGERs-Mannheim/vision-processor)
+
+Both softwares detect the same approved jersey patterns, and produce the same network packets. Teams need to ensure that their systems are compatible with the shared vision system output and that their systems are able to handle the typical properties of real-world sensory data as provided by the shared vision system (including noise, latency, or occasional failed detections and misclassifications). The vision patterns on the top of the robots must adhere to the specifications defined at SSL-Vision. Teams must use the color paper specified (or provided) by the event organizers.
 
 競技会の主催者からの発表があった場合や特別に許可されている場合を除いて、共有ビジョン機器のそばに、チーム独自のカメラや外部のセンサーを取り付けることは許されない。 +
 Besides the shared vision equipment, teams are not allowed to mount their own cameras or other external sensors, unless specifically announced or permitted by the respective competition organizers.
 
 SSL-Vision は、フィルタリングされ拡充されたデータを含む追加の https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_wrapper_tracked.proto[tracker protocol] を定義する。このメッセージは SSL-Vision それ自身によって公開されることは無いが、たとえばいずれかの<<オートレフ/Automatic Referee, オートレフ>>がそれを行う事がある。
 これは<<Game Controller, Game Controller>>や、洗練されたフィルタを保有していないチームによって使用される事を意図している。 +
-SSL-Vision defines an additional https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_wrapper_tracked.proto[tracker protocol] that contains filtered and enriched tracking data. Messages are not published by SSL-Vision itself, but for example by some <<オートレフ/Automatic Referee, automatic referees>>.
+The league defines an additional https://github.com/RoboCup-SSL/ssl-vision/blob/master/src/shared/proto/messages_robocup_ssl_wrapper_tracked.proto[tracker protocol] that contains filtered and enriched tracking data. Messages are not published by the shared vision system itself, but for example by some <<オートレフ/Automatic Referee, automatic referees>>.
 It is meant to be used by the <<Game Controller, game controller>> and by teams that do not yet have their own sophisticated filter.
 
 NOTE: (訳者注記)一般的に「ビジョン」と呼称されることが多い。

--- a/chapters/playingenvironment.adoc
+++ b/chapters/playingenvironment.adoc
@@ -124,14 +124,16 @@ For official matches, the <<組織委員会/Organizing Committee, organizing com
 The shared software used in the Small Size League is maintained by the <<技術委員会/Technical Committee, technical committee>>, though everyone is encouraged to contribute. The <<技術委員会/Technical Committee, technical committee>> members however guarantee that any changes made less than three months before the next RoboCup do not break compatibility.
 
 ==== Vision
-それぞれのフィールドには共有のビジョンサーバーと共有のカメラが設置されている。この共有ビジョン機器はコミュニティーにメンテナンスされているSSL-Vision ソフトウェア(https://github.com/RoboCup-SSL/ssl-vision) が使用される。SSL-Visionはイーサーネット経由で競技会の前に共有ビジョンシステム開発者によって通達されたパケット形式で位置情報を各チームに提供する。各チームはシステムが共有ビジョンシステムと互換性があり、システムが共有ビジョンシステムによって提供される実際のセンサーのデータの(ノイズ、レイテンシ、誤検出、欠落を含む)典型的な特性を処理できることを確認する必要がある。ロボット最上部にあるビジョンパターンはSSL-Visionの仕様に準拠している必要があり、SSL-Visionのマニュアルで指定されている標準のカラーペーパーでなければならない。 +
+それぞれのフィールドには共有のビジョンと共有のカメラが設置されている。この共有ビジョン機器はイーサーネット経由で競技会の前に共有ビジョンシステム開発者によって通達されたパケット形式で位置情報を各チームに提供する。複数のビジョンシステムが競技イベントでの使用を承認されている場合、主催者はどのシステムが使用可能であるかを事前に説明する。 +
 Each field is provided with a shared vision system and a set of shared cameras. This shared vision equipment provides localization data to teams via Ethernet in a packet format that is to be announced by the shared vision system developers before the competition. If multiple vision systems are approved for a competitive event, the organizers will describe in advance which one(s) will be available for use.
 
+競技イベントでの使用を承認されたソフトウェア実装は現時点で2種類存在する。 +
 There are currently two software implementations that are approved for use at a competitive event.
 
 - SSL-Vision (https://github.com/RoboCup-SSL/ssl-vision)
 - Vision Processor (https://github.com/TIGERs-Mannheim/vision-processor)
 
+いずれのソフトウェアも同一のパターンを認識し、同一のネットワークパケットを生成する。各チームはシステムが共有ビジョンシステムと互換性があり、システムが共有ビジョンシステムによって提供される実際のセンサーのデータの(ノイズ、レイテンシ、誤検出、欠落を含む)典型的な特性を処理できることを確認する必要がある。ロボット最上部にあるビジョンパターンはSSL-Visionで定義された仕様を尊寿する必要がある。チームはイベント主催者によって指定される(もしくは提供される)カラーペーパーを使用しなければならない。 +
 Both softwares detect the same approved jersey patterns, and produce the same network packets. Teams need to ensure that their systems are compatible with the shared vision system output and that their systems are able to handle the typical properties of real-world sensory data as provided by the shared vision system (including noise, latency, or occasional failed detections and misclassifications). The vision patterns on the top of the robots must adhere to the specifications defined at SSL-Vision. Teams must use the color paper specified (or provided) by the event organizers.
 
 競技会の主催者からの発表があった場合や特別に許可されている場合を除いて、共有ビジョン機器のそばに、チーム独自のカメラや外部のセンサーを取り付けることは許されない。 +


### PR DESCRIPTION
[本家Pull Request 105](https://github.com/robocup-ssl/ssl-rules/pull/105)の作業です。  

現状のルールでは共有ビジョンシステムとして SSL-Vision のみを想定していたため、TIGERs製の vision-processor など複数のソフトウェア実装を許容する文面に修正します。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review