### PR TITLE
Rules2026/106 同一チーム内におけるロボット高さの差異に制限を追加

### DIFF
--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -29,8 +29,10 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければならない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
+試合に参加する同一チームの全てのロボットの高さの差は、互いに0.02m以内でなければならない(たとえば、ロボットの高さの最高値と最低値の差は0.02m以内とする)。共有ビジョンシステムはチーム内でのロボットの高さの差異を補正せず、リーグはそのような機能をサポートすることを意図しない。ロボットの高さを同程度に保つことで、共有される位置データが正確になり、競技に参加するすべてのチームにとって公平性が確保される。 +
 The height of all robots of one team participating in a match must be within 0.02 meters of each other (e.g. the maximum and minimum robot heights may differ by no more than 0.02 meters). The shared vision system does not support correcting for different robot heights, and the league does not intend to support this feature. Keeping robot heights similar ensures shared localization data is accurate and fair for all participating teams.
 
+ビジョンシステムにおけるロボットの高さは次のように指定される: h~min~ + 0.5 * (h~max~ - h~min~)+
 The robot height in the vision system shall be specified as: h~min~ + 0.5 * (h~max~ - h~min~).
 
 ==== ロボットの色/Color of Robots

--- a/chapters/robots.adoc
+++ b/chapters/robots.adoc
@@ -29,6 +29,10 @@ The <<主審/Referee, referee>> has to force a team to remove a robot from the f
 ロボットはいかなる時点においても、直径0.18m、高さ0.15m以下の大きさでなければならない。さらに、ロボットの上面はstandard patternのサイズおよび表面の制約を満たさなければならない。 +
 A robot must fit inside a 0.18 meters wide and 0.15 meters high cylinder at any point in time. Additionally, the top of the robot must adhere to the standard pattern size and surface constraints.
 
+The height of all robots of one team participating in a match must be within 0.02 meters of each other (e.g. the maximum and minimum robot heights may differ by no more than 0.02 meters). The shared vision system does not support correcting for different robot heights, and the league does not intend to support this feature. Keeping robot heights similar ensures shared localization data is accurate and fair for all participating teams.
+
+The robot height in the vision system shall be specified as: h~min~ + 0.5 * (h~max~ - h~min~).
+
 ==== ロボットの色/Color of Robots
 試合中に明確に識別できるようにするため、ロボットは視覚的に相手チームと区別できる必要がある。以下のルールが適用される: +
 To ensure clear identification during gameplay, robots must be visually distinguishable from the opposing team. The following rules apply:


### PR DESCRIPTION
[本家Pull Request 106](https://github.com/robocup-ssl/ssl-rules/pull/106)の作業です。  

同一チーム内におけるロボットの高さの差異を0.02m以下とする制限を追加します。

- [x] cherry-pick
- [x] resolve conflict
- [x] translation
- [ ] review